### PR TITLE
🪛 OpenAPI enable/disable for ChildEsmerald and formatting issues

### DIFF
--- a/docs_src/configurations/staticfiles/settings.py
+++ b/docs_src/configurations/staticfiles/settings.py
@@ -2,6 +2,7 @@ from esmerald import EsmeraldAPISettings, StaticFilesConfig
 
 from pathlib import Path
 
+
 class CustomSettings(EsmeraldAPISettings):
     @property
     def static_files_config(self) -> StaticFilesConfig:

--- a/docs_src/configurations/template/settings.py
+++ b/docs_src/configurations/template/settings.py
@@ -3,6 +3,7 @@ from esmerald.template import JinjaTemplateEngine
 
 from pathlib import Path
 
+
 class CustomSettings(EsmeraldAPISettings):
     @property
     def template_config(self) -> TemplateConfig:


### PR DESCRIPTION
When adding a ChildEsmerald/Esmerald submodule and `openapi_schema=False`, it was still generating the documentation. This fix makes sure that `Include(include_in_schema=...)` is also being properly checked. 