### PR TITLE
docs: wording: "skip this step", not "jump this step"

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This will also generate a file for the tests using the EsmeraldTestClient, so ma
 $ pip install esmerald[test]
 ```
 
-Or you can jump this step if you don't want to use the EsmeraldTestClient.
+Or you can skip this step if you don't want to use the EsmeraldTestClient.
 
 You can find [more information](https://esmerald.dymmond.com/management/directives) about this directive and how to
 use it.

--- a/docs/directives/directives.md
+++ b/docs/directives/directives.md
@@ -294,7 +294,7 @@ The test files generated are using the EsmeraldTestClient, so make sure you run:
 $ pip install esmerald[test]
 ```
 
-Or you can jump this step if you don't want to use the EsmeraldTestClient at all.
+Or you can skip this step if you don't want to use the EsmeraldTestClient at all.
 
 ## Show URLs
 

--- a/docs/esmerald.md
+++ b/docs/esmerald.md
@@ -128,7 +128,7 @@ This will also generate a file for the tests using the EsmeraldTestClient, so ma
 $ pip install esmerald[test]
 ```
 
-Or you can jump this step if you don't want to use the EsmeraldTestClient.
+Or you can skip this step if you don't want to use the EsmeraldTestClient.
 
 You can find [more information](./directives/directives.md) about this directive and how to use it with a detailed
 example.


### PR DESCRIPTION
(In English, if a step is being left out, it's being "skipped", not "jumped".)