### PR TITLE
fix install script, use self-referencing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ Source = "https://github.com/dymmond/esmerald"
 
 [project.optional-dependencies]
 test = ["httpx>=0.25.0,<0.30.0"]
-
 dev = [
     # includes watchfiles
     "uvicorn[standard]>=0.24.0",
@@ -103,9 +102,13 @@ templates = ["mako>=1.2.4,<2.0.0"]
 jwt = ["passlib==1.7.4", "python-jose>=3.3.0,<4"]
 encoders = ["ujson>=5.7.0,<6"]
 schedulers = ["asyncz>=0.4.0"]
+all = ["esmerald[test,dev,templates,jwt,encoders,schedulers]","ipython","ptpython","a2wsgi"]
+
+
 
 [tool.hatch.envs.default]
 dependencies = ["ruff", "pre-commit>=2.17.0,<3.0.0", "twine"]
+
 [tool.hatch.envs.default.scripts]
 clean_pyc = "find . -type f -name \"*.pyc\" -delete"
 clean_pyi = "find . -type f -name \"*.pyi\" -delete"
@@ -115,6 +118,8 @@ lint = "ruff check --fix --line-length 99 esmerald tests docs_src {args}"
 
 
 [tool.hatch.envs.docs]
+detached = true
+skip-install = true
 dependencies = [
     "a2wsgi>=1.9.0,<2",
     "griffe-typingdoc>=0.2.2",
@@ -134,35 +139,24 @@ build = "mkdocs build"
 serve = "mkdocs serve --dev-addr localhost:8000"
 
 [tool.hatch.envs.test]
+features = ["all"]
 dependencies = [
     "pytest>=7.1.3,<9.0.0",
     "pytest-cov>=4.1.0,<6.0.0",
     "pytest-asyncio>=0.20.0",
     "mypy==1.9.0",
-    "aiofiles>=0.8.0,<24",
-    "a2wsgi>=1.9.0,<2",
-    "asyncz>=0.6.0",
     "anyio[trio]>=3.6.2,<5.0.0",
-    "httpx>=0.25.0,<0.30.0",
     "brotli>=1.0.9,<2.0.0",
     "flask>=1.1.2,<4.0.0",
     "freezegun>=1.2.2,<2.0.0",
-    "mock==5.1.0",
-    "passlib==1.7.4",
     "polyfactory>=2.5.0,<3.0.0",
-    "python-jose>=3.3.0,<4",
     "saffier[postgres]>=1.3.7",
     "edgy[postgres]>=0.4.0",
     "mongoz>=0.6.0",
-    "ujson>=5.7.0,<6",
 
     # types
     "types-ujson==5.9.0.0",
     "types-orjson==3.6.2",
-    "ipython",
-    "ptpython",
-    "uvicorn",
-
 ]
 [tool.hatch.envs.test.scripts]
 # needs docker services running
@@ -170,6 +164,15 @@ test = "ESMERALD_SETTINGS_MODULE='tests.settings.TestSettings' pytest {args}"
 coverage = "ESMERALD_SETTINGS_MODULE='tests.settings.TestSettings' pytest --cov=asyncz --cov=tests --cov-report=term-missing:skip-covered --cov-report=html tests {args}"
 check_types = "mypy -p lilya"
 
+
+[tool.hatch.envs.hatch-test]
+features = ["all"]
+template = "test"
+installer = "pip"
+
+[tool.hatch.envs.hatch-test.scripts]
+run = "ESMERALD_SETTINGS_MODULE='tests.settings.TestSettings' pytest{env:HATCH_TEST_ARGS:} {args}"
+run-cov = "ESMERALD_SETTINGS_MODULE='tests.settings.TestSettings' coverage run -m pytest{env:HATCH_TEST_ARGS:} {args}"
 
 [tool.hatch.version]
 path = "esmerald/__init__.py"

--- a/scripts/install
+++ b/scripts/install
@@ -17,4 +17,4 @@ else
 fi
 
 "$PIP" install -U pip
-"$PIP" install -e .[dev,test,doc,templates,jwt,encoders,schedulers,ipython,ptpython]
+"$PIP" install -e .[all]


### PR DESCRIPTION
- Better definition of dependencies. Use self referencing (supported since a few pypi versions)
- Rewire test to provide support for the new cool hatch command: "test"
- detach docs, no need to expose them as extra, or to install the project for them