### PR TITLE
Fix dependency injection with encoders

### DIFF
--- a/esmerald/encoders.py
+++ b/esmerald/encoders.py
@@ -66,7 +66,7 @@ class PydanticEncoder(Encoder):
         return obj.model_dump()
 
     def encode(self, annotation: Any, value: Any) -> Any:
-        if isinstance(value, BaseModel):
+        if isinstance(value, BaseModel) or is_class_and_subclass(value, BaseModel):
             return value
         return annotation(**value)
 

--- a/esmerald/transformers/utils.py
+++ b/esmerald/transformers/utils.py
@@ -1,4 +1,16 @@
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Set, Tuple, Type, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    ForwardRef,
+    List,
+    NamedTuple,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from lilya.datastructures import URL
 from pydantic.fields import FieldInfo
@@ -209,8 +221,12 @@ def get_signature(value: Any) -> Type["SignatureModel"]:
 
 
 def get_field_definition_from_param(param: "Parameter") -> Tuple[Any, Any]:
+    annotation = (
+        ForwardRef(param.annotation) if isinstance(param.annotation, str) else param.annotation
+    )
+
     if param.default_defined:
-        definition = param.annotation, param.default
+        definition = annotation, param.default
     elif not param.optional:
-        definition = param.annotation, ...
+        definition = annotation, ...
     return definition

--- a/tests/dependencies/test_simple_case_injected.py
+++ b/tests/dependencies/test_simple_case_injected.py
@@ -1,4 +1,4 @@
-from typing import AsyncGenerator, Type
+from typing import AsyncGenerator, List, Type
 
 import edgy
 import pytest
@@ -38,7 +38,7 @@ class DocumentService:
 
 
 class DocumentAPIView(APIView):
-    tags: list[str] = ["Document"]
+    tags: List[str] = ["Document"]
     dependencies = {
         "service": Inject(DocumentService),
     }

--- a/tests/dependencies/test_simple_case_injected.py
+++ b/tests/dependencies/test_simple_case_injected.py
@@ -1,0 +1,83 @@
+from typing import AsyncGenerator, Type
+
+import edgy
+import pytest
+from httpx import AsyncClient
+from pydantic import BaseModel
+
+from esmerald import Esmerald, post
+from esmerald.conf import settings
+from esmerald.injector import Inject
+from esmerald.routing.apis.views import APIView
+from esmerald.routing.gateways import Gateway
+
+database, models = settings.edgy_registry
+pytestmark = pytest.mark.anyio
+
+
+class Document(edgy.Model):
+    name = edgy.CharField(max_length=255)
+    content = edgy.TextField()
+
+    class Meta:
+        registry = models
+
+
+class DocumentCreateDTO(BaseModel):
+    name: str
+    content: str
+
+
+class DocumentService:
+
+    def __init__(self, model: Type[edgy.Model] = Document):
+        self.model = model
+
+    async def create(self, dto: DocumentCreateDTO) -> Document:
+        return await self.model.query.create(**dto.model_dump())
+
+
+class DocumentAPIView(APIView):
+    tags: list[str] = ["Document"]
+    dependencies = {
+        "service": Inject(DocumentService),
+    }
+
+    @post("/")
+    async def create(self, data: DocumentCreateDTO, service: DocumentService) -> Document:
+        return await service.create(data)
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def create_test_database():
+    try:
+        await models.create_all()
+        yield
+        await models.drop_all()
+    except Exception:
+        pytest.skip("No database available")
+
+
+@pytest.fixture(autouse=True)
+async def rollback_transactions():
+    with database.force_rollback():
+        async with database:
+            yield
+
+
+@pytest.fixture()
+def app():
+    app = Esmerald(routes=[Gateway(handler=DocumentAPIView)])
+    return app
+
+
+@pytest.fixture()
+async def async_client(app) -> AsyncGenerator:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac
+
+
+async def test_injection(async_client):
+    response = await async_client.post("/", json={"name": "test", "content": "test"})
+    assert response.status_code == 201
+    assert response.json() == {"name": "test", "content": "test"}

--- a/tests/dependencies/test_simple_case_injected_no_construct.py
+++ b/tests/dependencies/test_simple_case_injected_no_construct.py
@@ -1,0 +1,81 @@
+from typing import AsyncGenerator
+
+import edgy
+import pytest
+from httpx import AsyncClient
+from pydantic import BaseModel
+
+from esmerald import Esmerald, post
+from esmerald.conf import settings
+from esmerald.injector import Inject
+from esmerald.routing.apis.views import APIView
+from esmerald.routing.gateways import Gateway
+
+database, models = settings.edgy_registry
+pytestmark = pytest.mark.anyio
+
+
+class Document(edgy.Model):
+    name = edgy.CharField(max_length=255)
+    content = edgy.TextField()
+
+    class Meta:
+        registry = models
+
+
+class DocumentCreateDTO(BaseModel):
+    name: str
+    content: str
+
+
+class DocumentService:
+    model = Document
+
+    async def create(self, dto: DocumentCreateDTO) -> Document:
+        return await self.model.query.create(**dto.model_dump())
+
+
+class DocumentAPIView(APIView):
+    tags: list[str] = ["Document"]
+    dependencies = {
+        "service": Inject(DocumentService),
+    }
+
+    @post("/")
+    async def create(self, data: DocumentCreateDTO, service: DocumentService) -> Document:
+        return await service.create(data)
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def create_test_database():
+    try:
+        await models.create_all()
+        yield
+        await models.drop_all()
+    except Exception:
+        pytest.skip("No database available")
+
+
+@pytest.fixture(autouse=True)
+async def rollback_transactions():
+    with database.force_rollback():
+        async with database:
+            yield
+
+
+@pytest.fixture()
+def app():
+    app = Esmerald(routes=[Gateway(handler=DocumentAPIView)])
+    return app
+
+
+@pytest.fixture()
+async def async_client(app) -> AsyncGenerator:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac
+
+
+async def test_injection(async_client):
+    response = await async_client.post("/", json={"name": "test", "content": "test"})
+    assert response.status_code == 201
+    assert response.json() == {"name": "test", "content": "test"}

--- a/tests/dependencies/test_simple_case_injected_no_construct.py
+++ b/tests/dependencies/test_simple_case_injected_no_construct.py
@@ -1,4 +1,4 @@
-from typing import AsyncGenerator
+from typing import AsyncGenerator, List
 
 import edgy
 import pytest
@@ -36,7 +36,7 @@ class DocumentService:
 
 
 class DocumentAPIView(APIView):
-    tags: list[str] = ["Document"]
+    tags: List[str] = ["Document"]
     dependencies = {
         "service": Inject(DocumentService),
     }


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.


Fix dependency checking with PydanticEncoder failing checking the subclasses.