### PR TITLE
Addressing the `from __future__ import annotations`

### DIFF
--- a/esmerald/transformers/utils.py
+++ b/esmerald/transformers/utils.py
@@ -1,16 +1,4 @@
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    ForwardRef,
-    List,
-    NamedTuple,
-    Set,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Set, Tuple, Type, Union, cast
 
 from lilya.datastructures import URL
 from pydantic.fields import FieldInfo
@@ -221,9 +209,13 @@ def get_signature(value: Any) -> Type["SignatureModel"]:
 
 
 def get_field_definition_from_param(param: "Parameter") -> Tuple[Any, Any]:
-    annotation = (
-        ForwardRef(param.annotation) if isinstance(param.annotation, str) else param.annotation
-    )
+    """
+    This method will make sure that __future__ references are resolved by
+    the Any type. This is necessary because the signature model will be
+    generated before the actual type is resolved.
+    """
+
+    annotation = Any if isinstance(param.annotation, str) else param.annotation
 
     if param.default_defined:
         definition = annotation, param.default

--- a/tests/dependencies/samples.py
+++ b/tests/dependencies/samples.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class DocumentCreateDTO(BaseModel):
+    name: str
+    content: str
+
+
+class DocumentService:
+
+    async def create(self, dto: DocumentCreateDTO) -> DocumentCreateDTO:
+        if isinstance(dto, dict):
+            doc = DocumentCreateDTO(**dto)
+        else:
+            doc = DocumentCreateDTO(**dto.model_dump())
+        return doc

--- a/tests/dependencies/test_simple_case_injected_annotation.py
+++ b/tests/dependencies/test_simple_case_injected_annotation.py
@@ -1,0 +1,32 @@
+from typing import TYPE_CHECKING, List
+
+from esmerald import post
+from esmerald.injector import Inject
+from esmerald.routing.apis.views import APIView
+from esmerald.routing.gateways import Gateway
+from esmerald.testclient import create_client
+from tests.dependencies.samples import DocumentService
+
+if TYPE_CHECKING:
+    from tests.dependencies.samples import DocumentCreateDTO
+
+
+class DocumentAPIView(APIView):
+    tags: List[str] = ["Document"]
+    dependencies = {
+        "service": Inject(DocumentService),
+    }
+
+    @post("/")
+    async def create(
+        self, data: "DocumentCreateDTO", service: "DocumentService"
+    ) -> "DocumentCreateDTO":
+        return await service.create(data)
+
+
+def test_injection():
+
+    with create_client(routes=[Gateway(handler=DocumentAPIView)]) as client:
+        response = client.post("/", json={"name": "test", "content": "test"})
+        assert response.status_code == 201
+        assert response.json() == {"name": "test", "content": "test"}

--- a/tests/dependencies/test_simple_case_injected_annotation_from_future.py
+++ b/tests/dependencies/test_simple_case_injected_annotation_from_future.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import List
+
+from esmerald import post
+from esmerald.injector import Inject
+from esmerald.routing.apis.views import APIView
+from esmerald.routing.gateways import Gateway
+from esmerald.testclient import create_client
+from tests.dependencies.samples import DocumentCreateDTO, DocumentService
+
+
+class DocumentAPIView(APIView):
+    tags: List[str] = ["Document"]
+    dependencies = {
+        "service": Inject(DocumentService),
+    }
+
+    @post("/")
+    async def create(
+        self, data: DocumentCreateDTO, service: DocumentService
+    ) -> "DocumentCreateDTO":
+        return await service.create(data)
+
+
+def test_injection():
+
+    with create_client(routes=[Gateway(handler=DocumentAPIView)]) as client:
+        response = client.post("/", json={"name": "test", "content": "test"})
+        assert response.status_code == 201
+        assert response.json() == {"name": "test", "content": "test"}


### PR DESCRIPTION
This addresses the cases where the dependency injection was failing to under the `__future__ import annotations` and this was causing issues.

This also means if a `data: "Something"` is passed, it will always treat as `Any` and it won't reflect in the OpenAPI documentation.

### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.
