### PR TITLE
Default responses detection for OpenAPI

### DIFF
--- a/esmerald/transformers/signature.py
+++ b/esmerald/transformers/signature.py
@@ -1,5 +1,6 @@
 import re
-from inspect import Parameter as InspectParameter, Signature as InspectSignature
+from inspect import Parameter as InspectParameter
+from inspect import Signature as InspectSignature
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/esmerald/transformers/signature.py
+++ b/esmerald/transformers/signature.py
@@ -1,6 +1,5 @@
 import re
-from inspect import Parameter as InspectParameter
-from inspect import Signature as InspectSignature
+from inspect import Parameter as InspectParameter, Signature as InspectSignature
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/esmerald/transformers/utils.py
+++ b/esmerald/transformers/utils.py
@@ -2,7 +2,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    ForwardRef,
     List,
     NamedTuple,
     Set,
@@ -12,7 +11,7 @@ from typing import (
     cast,
 )
 
-from pydantic import TypeAdapter
+from lilya.datastructures import URL
 from pydantic.fields import FieldInfo
 
 from esmerald.enums import ParamType, ScopeType
@@ -22,7 +21,6 @@ from esmerald.parsers import ArbitraryExtraBaseModel, HashableBaseModel
 from esmerald.requests import Request
 from esmerald.typing import Undefined
 from esmerald.utils.constants import REQUIRED
-from lilya.datastructures import URL
 
 if TYPE_CHECKING:  # pragma: no cover
     from esmerald.injector import Inject

--- a/esmerald/transformers/utils.py
+++ b/esmerald/transformers/utils.py
@@ -1,6 +1,18 @@
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Set, Tuple, Type, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    ForwardRef,
+    List,
+    NamedTuple,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
-from lilya.datastructures import URL
+from pydantic import TypeAdapter
 from pydantic.fields import FieldInfo
 
 from esmerald.enums import ParamType, ScopeType
@@ -10,6 +22,7 @@ from esmerald.parsers import ArbitraryExtraBaseModel, HashableBaseModel
 from esmerald.requests import Request
 from esmerald.typing import Undefined
 from esmerald.utils.constants import REQUIRED
+from lilya.datastructures import URL
 
 if TYPE_CHECKING:  # pragma: no cover
     from esmerald.injector import Inject

--- a/tests/openapi/detection/test_default_response.py
+++ b/tests/openapi/detection/test_default_response.py
@@ -1,0 +1,53 @@
+from typing import Union
+
+from pydantic import BaseModel
+
+from esmerald import Gateway, JSONResponse, get
+from esmerald.testclient import create_client
+from tests.settings import TestSettings
+
+
+class Item(BaseModel):
+    sku: Union[int, str]
+
+
+@get()
+def read_item() -> JSONResponse:
+    """ """
+
+
+def test_open_api_schema(test_client_factory):
+    with create_client(
+        routes=[Gateway(handler=read_item)],
+        enable_openapi=True,
+        include_in_schema=True,
+        settings_module=TestSettings,
+    ) as client:
+        response = client.get("/openapi.json")
+
+        assert response.json() == {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Esmerald",
+                "summary": "Esmerald application",
+                "description": "Highly scalable, performant, easy to learn and for every application.",
+                "contact": {"name": "admin", "email": "admin@myapp.com"},
+                "version": client.app.version,
+            },
+            "servers": [{"url": "/"}],
+            "paths": {
+                "/": {
+                    "get": {
+                        "summary": "Read Item",
+                        "operationId": "read_item__get",
+                        "responses": {
+                            "200": {
+                                "description": "Successful response",
+                                "content": {"application/json": {"schema": {"type": "string"}}},
+                            }
+                        },
+                        "deprecated": False,
+                    }
+                }
+            },
+        }

--- a/tests/openapi/detection/test_default_response_with_none.py
+++ b/tests/openapi/detection/test_default_response_with_none.py
@@ -1,0 +1,48 @@
+from typing import Union
+
+from pydantic import BaseModel
+
+from esmerald import Gateway, get
+from esmerald.testclient import create_client
+from tests.settings import TestSettings
+
+
+class Item(BaseModel):
+    sku: Union[int, str]
+
+
+@get()
+def read_item() -> None:
+    """ """
+
+
+def test_open_api_schema(test_client_factory):
+    with create_client(
+        routes=[Gateway(handler=read_item)],
+        enable_openapi=True,
+        include_in_schema=True,
+        settings_module=TestSettings,
+    ) as client:
+        response = client.get("/openapi.json")
+
+        assert response.json() == {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Esmerald",
+                "summary": "Esmerald application",
+                "description": "Highly scalable, performant, easy to learn and for every application.",
+                "contact": {"name": "admin", "email": "admin@myapp.com"},
+                "version": client.app.version,
+            },
+            "servers": [{"url": "/"}],
+            "paths": {
+                "/": {
+                    "get": {
+                        "summary": "Read Item",
+                        "operationId": "read_item__get",
+                        "responses": {"200": {"description": "Successful response"}},
+                        "deprecated": False,
+                    }
+                }
+            },
+        }

--- a/tests/openapi/detection/test_detect_openapi_override.py
+++ b/tests/openapi/detection/test_detect_openapi_override.py
@@ -1,0 +1,105 @@
+from typing import Union
+
+from pydantic import BaseModel
+
+from esmerald import Gateway, get
+from esmerald.openapi.datastructures import OpenAPIResponse
+from esmerald.testclient import create_client
+from tests.settings import TestSettings
+
+
+class Item(BaseModel):
+    sku: Union[int, str]
+
+
+class ResponseOut(BaseModel):
+    status: str
+    message: str
+
+
+class Another(BaseModel):
+    status: str
+    message: str
+
+
+@get(
+    responses={
+        200: OpenAPIResponse(model=Item, description="Override default response of 200"),
+        201: OpenAPIResponse(model=Another),
+    }
+)
+def read_item() -> ResponseOut:
+    """ """
+
+
+def test_open_api_schema(test_client_factory):
+    with create_client(
+        routes=[Gateway(handler=read_item)],
+        enable_openapi=True,
+        include_in_schema=True,
+        settings_module=TestSettings,
+    ) as client:
+        response = client.get("/openapi.json")
+
+        assert response.json() == {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Esmerald",
+                "summary": "Esmerald application",
+                "description": "Highly scalable, performant, easy to learn and for every application.",
+                "contact": {"name": "admin", "email": "admin@myapp.com"},
+                "version": client.app.version,
+            },
+            "servers": [{"url": "/"}],
+            "paths": {
+                "/": {
+                    "get": {
+                        "summary": "Read Item",
+                        "operationId": "read_item__get",
+                        "responses": {
+                            "200": {
+                                "description": "Override default response of 200",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/Item"}
+                                    }
+                                },
+                            },
+                            "201": {
+                                "description": "Additional response",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/Another"}
+                                    }
+                                },
+                            },
+                        },
+                        "deprecated": False,
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "Another": {
+                        "properties": {
+                            "status": {"type": "string", "title": "Status"},
+                            "message": {"type": "string", "title": "Message"},
+                        },
+                        "type": "object",
+                        "required": ["status", "message"],
+                        "title": "Another",
+                    },
+                    "Item": {
+                        "properties": {
+                            "sku": {
+                                "anyOf": [{"type": "integer"}, {"type": "string"}],
+                                "title": "Sku",
+                            }
+                        },
+                        "type": "object",
+                        "required": ["sku"],
+                        "title": "Item",
+                    },
+                }
+            },
+        }

--- a/tests/openapi/detection/test_detect_openapi_response.py
+++ b/tests/openapi/detection/test_detect_openapi_response.py
@@ -1,0 +1,70 @@
+from typing import Union
+
+from pydantic import BaseModel
+
+from esmerald import Gateway, get
+from esmerald.testclient import create_client
+from tests.settings import TestSettings
+
+
+class Item(BaseModel):
+    sku: Union[int, str]
+
+
+@get()
+def read_item() -> Item:
+    """ """
+
+
+def test_open_api_schema(test_client_factory):
+    with create_client(
+        routes=[Gateway(handler=read_item)],
+        enable_openapi=True,
+        include_in_schema=True,
+        settings_module=TestSettings,
+    ) as client:
+        response = client.get("/openapi.json")
+
+        assert response.json() == {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Esmerald",
+                "summary": "Esmerald application",
+                "description": "Highly scalable, performant, easy to learn and for every application.",
+                "contact": {"name": "admin", "email": "admin@myapp.com"},
+                "version": client.app.version,
+            },
+            "servers": [{"url": "/"}],
+            "paths": {
+                "/": {
+                    "get": {
+                        "summary": "Read Item",
+                        "operationId": "read_item__get",
+                        "responses": {
+                            "200": {
+                                "description": "Successful response",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "properties": {
+                                                "sku": {
+                                                    "anyOf": [
+                                                        {"type": "integer"},
+                                                        {"type": "string"},
+                                                    ],
+                                                    "title": "Sku",
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": ["sku"],
+                                            "title": "Item",
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                        "deprecated": False,
+                    }
+                }
+            },
+        }

--- a/tests/openapi/msgspec/test_msgspec.py
+++ b/tests/openapi/msgspec/test_msgspec.py
@@ -73,7 +73,25 @@ def test_user_msgspec_openapi(test_client_factory):
                         "responses": {
                             "201": {
                                 "description": "Successful response",
-                                "content": {"application/json": {"schema": {"type": "string"}}},
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "properties": {
+                                                "name": {"type": "string", "title": "Name"},
+                                                "email": {
+                                                    "anyOf": [
+                                                        {"type": "string"},
+                                                        {"type": "null"},
+                                                    ],
+                                                    "title": "Email",
+                                                },
+                                            },
+                                            "type": "object",
+                                            "required": ["name", "email"],
+                                            "title": "User",
+                                        }
+                                    }
+                                },
                             },
                             "422": {
                                 "description": "Validation Error",

--- a/tests/openapi/msgspec/test_msgspec_with_annotations.py
+++ b/tests/openapi/msgspec/test_msgspec_with_annotations.py
@@ -51,7 +51,19 @@ def test_user_msgspec_openapi(test_client_factory):
                         "responses": {
                             "201": {
                                 "description": "Successful response",
-                                "content": {"application/json": {"schema": {"type": "string"}}},
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "properties": {
+                                                "id": {"type": "integer", "title": "Id"},
+                                                "email": {"type": "string", "title": "Email"},
+                                            },
+                                            "type": "object",
+                                            "required": ["id", "email"],
+                                            "title": "Comment",
+                                        }
+                                    }
+                                },
                             },
                             "422": {
                                 "description": "Validation Error",

--- a/tests/openapi/test_openapi_include_middleware.py
+++ b/tests/openapi/test_openapi_include_middleware.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Union
 from lilya.types import ASGIApp, Receive, Scope, Send
 from pydantic import BaseModel
 
-from esmerald import JSON, Gateway, Include, MiddlewareProtocol, get
+from esmerald import Gateway, Include, MiddlewareProtocol, get
 from esmerald.testclient import create_client
 from tests.settings import TestSettings
 
@@ -32,7 +32,7 @@ def read_mode() -> Dict[str, str]:
 
 
 @get("/item")
-async def read_item() -> JSON:
+async def read_item() -> Dict[str, str]:
     """ """
 
 


### PR DESCRIPTION
### Checklist

- [ ] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [ ] I branched out from the latest main or is a sub-branch.


This introduces the automatic detection of a response in the OpenAPI if "responses" is not provided for the default status code of the handler.