### PR TITLE
Fix OpenAPI for query parameters

### DIFF
--- a/docs/en/docs/extras/cookie-fields.md
+++ b/docs/en/docs/extras/cookie-fields.md
@@ -73,7 +73,7 @@ from esmerald.datastructures import Cookie as ResponseCookie
 ### Cookie from params
 
 The cookie used with the [example](#cookie-as-a-param) as param is not a datastructure but a `FieldInfo` so it cannot
-be used to set and create a new `cookie` like the one from [response cookies](#cookie-from-response-cookies).
+be used to set and create a new `cookie` like the one from [response cookies](#response-cookies).
 
 To import it:
 

--- a/docs/en/docs/extras/index.md
+++ b/docs/en/docs/extras/index.md
@@ -1,1 +1,3 @@
-# Extras
+# Advanced & Useful
+
+Here you will find some more details about how to use some specials from Esmerald within your handlers.

--- a/docs/en/docs/extras/path-params.md
+++ b/docs/en/docs/extras/path-params.md
@@ -1,0 +1,112 @@
+# Path Parameters
+
+Path parameters are those, as the name suggests, parameters that are part of a URL (path) definition.
+
+You can declare the path parameters (you can think of them as variables) using the same python syntax for strings.
+
+```python
+{!> ../../../docs_src/extras/path/example.py !}
+```
+
+As you can see, the `user_id` declared in the path was also passed and provided in the function `user`. This is how
+you must declare path parameters in Esmerald.
+
+You can now access the URL:
+
+```shell
+http://127.0.0.1/users/1
+```
+
+## Declaration of the parameters
+
+**Esmerald** being developed on top of [Lilya][lilya] also means that it allows **two** different syntaxes for the declaration
+of the parameters.
+
+=== "Default"
+
+    ```python
+    {!> ../../../docs_src/extras/path/example.py !}
+    ```
+
+=== "Less than/Greater than"
+
+    ```python
+    {!> ../../../docs_src/extras/path/example_gt.py !}
+    ```
+
+Esmerald allows the use of `{}` and `<>` syntaxes. Both work in an `equal` way and the reasoning for that is only to
+allow the users to choose their own preference.
+
+## Default parameters
+
+When declaring a controller with path parameters, if no type is specified in the `string` declaration, Esmerald will assume
+it will be of type `string`.
+
+```python
+{!> ../../../docs_src/extras/path/example.py !}
+```
+
+If you wish to specifiy exactly the type for the path parameter, you can do it by liteally specifiying the type of the
+parameter.
+
+```python
+{!> ../../../docs_src/extras/path/example_type.py !}
+```
+
+This will make sure it will enforce the type `int` and throws an error if an invalid integer is provided.
+
+When providing the path parameters with a proper typing, this will also make sure the [OpenAPI](../openapi.md) documentation
+will have the right type for you to test.
+
+## Custom typing and transformers
+
+What if you need to create a custom typing that is not natively supported by Esmerald? Well, Esmerald has your back with
+the [transformers](../routing/routes.md#custom-transformers).
+
+This will make sure you have your own transformer for your own unique typing and Esmerald can understand it.
+
+Since Esmerald is built on top of [Lilya][lilya], that means it also supports natively the same types.
+
+You can [check here for more details](../routing/routes.md#path-parameters).
+
+## Enums
+
+Esmerald also supports `Enum` types as typing. Yes, that's right, natively Esmerald handles Enums for you. This will
+trigger automatic validations of Esmerald in case a wrong value is provided.
+
+```python
+{!> ../../../docs_src/extras/path/enum.py !}
+```
+
+You can now call:
+
+```shell
+http://127.0.0.1/users/admin
+```
+
+If you, for example, provide something like this:
+
+```shell
+http://127.0.0.1/users/something
+```
+
+And since `something` is not declared in the Enum type, you will get an error similar to this:
+
+```json
+{
+    "detail": "Validation failed for http://127.0.0.1/users/something with method GET.",
+    "errors": [
+        {
+            "type": "enum",
+            "loc": ["item_type"],
+            "msg": "Input should be 'user' or 'admin'",
+            "input": "something",
+            "ctx": {"expected": "'user' or 'admin'"},
+            "url": "https://errors.pydantic.dev/2.8/v/enum",
+        }
+    ],
+}
+```
+
+
+[lilya]: https//lilya.dev

--- a/docs/en/docs/extras/query-params.md
+++ b/docs/en/docs/extras/query-params.md
@@ -1,0 +1,127 @@
+# Query Parameters
+
+It is very common to simply want to declare some query parameters in your controllers. Sometimes those are also used
+as filters for a given search or simply extra parameters in general.
+
+## What are query parameters in Esmerald?
+
+Query parameters are those parameters that are not part of the path parameters and therefore those are automatically
+injected as `query` parameters for you.
+
+```python
+{!> ../../../docs_src/extras/query/example1.py !}
+```
+
+As you can see, the query is a key-pair value that goes after the `?` in the URL and seperated by a `&`.
+
+Applying the previous example, it would look like this:
+
+```shell
+http://127.0.0.1/users?skip=1&limit=5
+```
+
+The previous url will be translated as the following `query_params`:
+
+- `skip`: with a value of 1.
+- `limit`: with a value of 5.
+
+Since they are an integral part of the URL, it will automatically populate the parameters of the function that corresponds
+each value.
+
+## Declaring defaults
+
+Query parameters are not by design, part of a fixed URL path and that also means they can assume the following:
+
+- They can have defaults, like `skip=1` and `limit=5`.
+- They can be `optional`.
+
+In the previous example, the URL had already defaults for `skip` and `limit` and the corresponding typing as per requirement
+of Esmerald but what if we want to make them optional?
+
+There are different ways of achieving that, using the `Optional` or `Union`.
+
+!!! Tip
+    from Python 3.10+ the `Union` can be replaced with `|` syntax.
+
+
+=== "Using Optional"
+
+    ```python
+    {!> ../../../docs_src/extras/query/example_optional.py !}
+    ```
+
+=== "Using Union"
+
+    ```python
+    {!> ../../../docs_src/extras/query/example_union.py !}
+    ```
+
+!!! Check
+    Esmerald is intelligent enough to understand what is a `query param` and what is a `path param`.
+
+Now we can call the URL and ignore the `q` or call it when needed, like this:
+
+**Without query params**
+
+```shell
+http://127.0.0.1/users/1
+```
+
+**With query params**
+
+```shell
+http://127.0.0.1/users/1?q=searchValue
+```
+
+## Query and Path parameters
+
+Since Esmerald is intelligent enough to distinguish path parameters and query parameters automatically, that also means
+you can have multiple of both combined.
+
+!!! Warning
+    You can't have a query and path parameters with the same name as in the end, it is still Python parameters being
+    declared in a function.
+
+```python
+{!> ../../../docs_src/extras/query/example_combined.py !}
+```
+
+## Required parameters
+
+When you declare a `query parameter` **without a default** and **without being optional** when you call the URL
+it will raise an error of missing value for the corresponding.
+
+```python
+{!> ../../../docs_src/extras/query/example_mandatory.py !}
+```
+
+If you call the URL like this:
+
+```
+http://127.0.0.1/users
+```
+
+It will raise an error of missing value, something like this:
+
+```json
+{
+  "detail": "Validation failed for <URL> with method GET.",
+  "errors": [
+    {
+      "type": "int_type",
+      "loc": [
+        "limit"
+      ],
+      "msg": "Input should be a valid integer",
+      "input": null,
+      "url": "https://errors.pydantic.dev/2.8/v/int_type"
+    }
+  ]
+}
+```
+
+Which means, you need to call with the declared parameter, like this, for example:
+
+```shell
+http://127.0.0.1/users?limit=10
+```

--- a/docs/en/docs/extras/query-params.md
+++ b/docs/en/docs/extras/query-params.md
@@ -125,3 +125,14 @@ Which means, you need to call with the declared parameter, like this, for exampl
 ```shell
 http://127.0.0.1/users?limit=10
 ```
+
+## Extra with Esmerald params
+
+Because everything in Esmerald just works you can also add restrictions and limits to your query parameters. For example.
+you might want to add a limit into the size of a string `q` when searching not to exceed an X value.
+
+```python
+{!> ../../../docs_src/extras/query/example_query.py !}
+```
+
+This basically tells that a `q` query parameters must not exceed the length of `10` of an exception will be raised.

--- a/docs/en/docs/extras/useful-index.md
+++ b/docs/en/docs/extras/useful-index.md
@@ -1,1 +1,0 @@
-# Extra, Advanced & Useful

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -5,6 +5,24 @@ hide:
 
 # Release Notes
 
+## 3.3.4
+
+### Added
+
+- Missing documentation for [Query Parameters](./extras/query-params.md) and [Path Parameters](./extras/path-params.md).
+
+### Changed
+
+- Documentation for `Extra, Advanced && Useful` is now renamed `Advanced & Useful` and its located in the `Features`
+section.
+- Removed unused internal functions for validations now used by Esmerald encoders.
+
+### Fixed
+
+- Regression caused by the introduction of the dynamic encoders when diplaying the query parameters in the OpenAPI
+documentation.
+- Annotation discovery for the Signature.
+
 ## 3.3.3
 
 ### Changed

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -126,6 +126,16 @@ nav:
   - background-tasks.md
   - lifespan-events.md
   - protocols.md
+  - Advanced & Useful:
+    - extras/index.md
+    - extras/path-params.md
+    - extras/query-params.md
+    - extras/request-data.md
+    - extras/upload-files.md
+    - extras/forms.md
+    - extras/body-fields.md
+    - extras/header-fields.md
+    - extras/cookie-fields.md
   - Scheduler:
     - scheduler/index.md
     - Asyncz:
@@ -159,16 +169,6 @@ nav:
       - databases/mongoz/example.md
 - openapi.md
 - Extras:
-  - extras/index.md
-  - Extra, Advanced & Useful:
-    - extras/useful-index.md
-    - extras/query-params.md
-    - extras/request-data.md
-    - extras/upload-files.md
-    - extras/forms.md
-    - extras/body-fields.md
-    - extras/header-fields.md
-    - extras/cookie-fields.md
   - wsgi.md
   - testclient.md
   - Deployment:

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
   - extras/index.md
   - Extra, Advanced & Useful:
     - extras/useful-index.md
+    - extras/query-params.md
     - extras/request-data.md
     - extras/upload-files.md
     - extras/forms.md

--- a/docs_src/extras/path/enum.py
+++ b/docs_src/extras/path/enum.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+from esmerald import Esmerald, Gateway, JSONResponse, get
+
+
+class UserEnum(Enum):
+    user = "user"
+    admin = "admin"
+
+
+@get("/users/{user_type}")
+async def read_user(user_type: UserEnum) -> JSONResponse: ...
+
+
+app = Esmerald(
+    routes=[
+        Gateway(read_user),
+    ]
+)

--- a/docs_src/extras/path/example.py
+++ b/docs_src/extras/path/example.py
@@ -1,0 +1,12 @@
+from esmerald import Esmerald, Gateway, JSONResponse, get
+
+
+@get("/users/{user_id}")
+async def read_user(user_id: str) -> JSONResponse: ...
+
+
+app = Esmerald(
+    routes=[
+        Gateway(read_user),
+    ]
+)

--- a/docs_src/extras/path/example_gt.py
+++ b/docs_src/extras/path/example_gt.py
@@ -1,0 +1,12 @@
+from esmerald import Esmerald, Gateway, JSONResponse, get
+
+
+@get("/users/<user_id>")
+async def read_user(user_id: str) -> JSONResponse: ...
+
+
+app = Esmerald(
+    routes=[
+        Gateway(read_user),
+    ]
+)

--- a/docs_src/extras/path/example_type.py
+++ b/docs_src/extras/path/example_type.py
@@ -1,0 +1,12 @@
+from esmerald import Esmerald, Gateway, JSONResponse, get
+
+
+@get("/users/{user_id:int}")
+async def read_user(user_id: int) -> JSONResponse: ...
+
+
+app = Esmerald(
+    routes=[
+        Gateway(read_user),
+    ]
+)

--- a/docs_src/extras/query/example1.py
+++ b/docs_src/extras/query/example1.py
@@ -1,0 +1,15 @@
+from esmerald import Esmerald, Gateway, JSONResponse, get
+
+fake_users = [{"last_name": "Doe", "email": "john.doe@example.com"}]
+
+
+@get("/users")
+async def read_user(skip: int = 1, limit: int = 5) -> JSONResponse:
+    return fake_users[skip : skip + limit]
+
+
+app = Esmerald(
+    routes=[
+        Gateway(read_user),
+    ]
+)

--- a/docs_src/extras/query/example_combined.py
+++ b/docs_src/extras/query/example_combined.py
@@ -1,0 +1,12 @@
+from esmerald import Esmerald, Gateway, JSONResponse, get
+
+
+@get("/users/{id}/{last_name}")
+async def read_user(id: int, last_name: str, skip: int = 1, limit: int = 5) -> JSONResponse: ...
+
+
+app = Esmerald(
+    routes=[
+        Gateway(read_user),
+    ]
+)

--- a/docs_src/extras/query/example_mandatory.py
+++ b/docs_src/extras/query/example_mandatory.py
@@ -1,0 +1,12 @@
+from esmerald import Esmerald, Gateway, JSONResponse, get
+
+
+@get("/users")
+async def read_user(limit: int) -> JSONResponse: ...
+
+
+app = Esmerald(
+    routes=[
+        Gateway(read_user),
+    ]
+)

--- a/docs_src/extras/query/example_optional.py
+++ b/docs_src/extras/query/example_optional.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from esmerald import Esmerald, Gateway, JSONResponse, get
+
+
+@get("/users/{id}")
+async def read_user(id: int, q: Optional[int] = None) -> JSONResponse: ...
+
+
+app = Esmerald(
+    routes=[
+        Gateway(read_user),
+    ]
+)

--- a/docs_src/extras/query/example_query.py
+++ b/docs_src/extras/query/example_query.py
@@ -1,0 +1,14 @@
+from typing import Union
+
+from esmerald import Esmerald, Gateway, JSONResponse, Query, get
+
+
+@get("/users")
+async def read_user(q: str = Query(max_length=10)) -> JSONResponse: ...
+
+
+app = Esmerald(
+    routes=[
+        Gateway(read_user),
+    ]
+)

--- a/docs_src/extras/query/example_union.py
+++ b/docs_src/extras/query/example_union.py
@@ -1,0 +1,14 @@
+from typing import Union
+
+from esmerald import Esmerald, Gateway, JSONResponse, get
+
+
+@get("/users/{id}")
+async def read_user(id: int, q: Union[int, None] = None) -> JSONResponse: ...
+
+
+app = Esmerald(
+    routes=[
+        Gateway(read_user),
+    ]
+)

--- a/esmerald/__init__.py
+++ b/esmerald/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.3.3"
+__version__ = "3.3.4"
 
 
 from lilya import status

--- a/esmerald/openapi/openapi.py
+++ b/esmerald/openapi/openapi.py
@@ -52,7 +52,10 @@ def get_flat_params(route: Union[router.HTTPHandler, Any]) -> List[Any]:
 
     query_params = []
     for param in route.transformer.get_query_params():
-        if param.field_info.annotation.__class__.__name__ in TRANSFORMER_TYPES.keys():
+        if (
+            param.field_info.annotation.__class__.__name__ in TRANSFORMER_TYPES.keys()
+            or param.field_info.annotation.__name__ in TRANSFORMER_TYPES.keys()
+        ):
             query_params.append(param.field_info)
 
     return path_params + query_params + cookie_params + header_params

--- a/esmerald/openapi/openapi.py
+++ b/esmerald/openapi/openapi.py
@@ -13,7 +13,7 @@ from orjson import loads
 from pydantic import AnyUrl
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
-from typing_extensions import Literal
+from typing_extensions import Literal, get_args
 
 from esmerald.enums import MediaType
 from esmerald.openapi.constants import METHODS_WITH_BODY, REF_PREFIX, REF_TEMPLATE
@@ -41,7 +41,7 @@ from esmerald.routing import gateways, router
 from esmerald.routing._internal import convert_annotation_to_pydantic_model
 from esmerald.typing import Undefined
 from esmerald.utils.constants import DATA, PAYLOAD
-from esmerald.utils.helpers import is_class_and_subclass
+from esmerald.utils.helpers import is_class_and_subclass, is_optional_union
 
 
 def get_flat_params(route: Union[router.HTTPHandler, Any]) -> List[Any]:
@@ -52,11 +52,23 @@ def get_flat_params(route: Union[router.HTTPHandler, Any]) -> List[Any]:
 
     query_params = []
     for param in route.transformer.get_query_params():
-        if (
-            param.field_info.annotation.__class__.__name__ in TRANSFORMER_TYPES.keys()
-            or param.field_info.annotation.__name__ in TRANSFORMER_TYPES.keys()
-        ):
-            query_params.append(param.field_info)
+        is_optional = is_optional_union(param.field_info.annotation)
+        if is_optional:
+            arguments = get_args(param.field_info.annotation)
+
+            for arg in arguments:
+                if (
+                    arg.__name__ in TRANSFORMER_TYPES.keys()
+                    or hasattr(arg, "annotation")
+                    and arg.__class__.__name__ in TRANSFORMER_TYPES.keys()
+                ):
+                    query_params.append(param.field_info)
+        else:
+            if (
+                param.field_info.annotation.__class__.__name__ in TRANSFORMER_TYPES.keys()
+                or param.field_info.annotation.__name__ in TRANSFORMER_TYPES.keys()
+            ):
+                query_params.append(param.field_info)
 
     return path_params + query_params + cookie_params + header_params
 

--- a/esmerald/transformers/utils.py
+++ b/esmerald/transformers/utils.py
@@ -1,15 +1,4 @@
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    NamedTuple,
-    Set,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Set, Tuple, Type, Union, cast
 
 from lilya.datastructures import URL
 from pydantic.fields import FieldInfo
@@ -232,4 +221,6 @@ def get_field_definition_from_param(param: "Parameter") -> Tuple[Any, Any]:
         definition = annotation, param.default
     elif not param.optional:
         definition = annotation, ...
+    else:
+        definition = annotation, None
     return definition

--- a/esmerald/utils/helpers.py
+++ b/esmerald/utils/helpers.py
@@ -1,14 +1,10 @@
 import sys
-import typing
-from inspect import isclass
 from typing import Any, Union
 
 import slugify
 from lilya._utils import is_class_and_subclass as is_class_and_subclass
 from lilya.compat import is_async_callable as is_async_callable
 from typing_extensions import get_args, get_origin
-
-from esmerald.datastructures.msgspec import Struct
 
 if sys.version_info >= (3, 10):
     from types import UnionType
@@ -18,31 +14,40 @@ else:  # pragma: no cover
     UNION_TYPES = {Union}
 
 
-def is_msgspec_struct(value: typing.Any) -> bool:
-    """
-    Analyses if is a msgspec.Struct and uses this for OpenAPI
-    documentation generation.
-    """
-    original = get_origin(value)
-    if not original and not isclass(value):
-        return False
-
-    try:
-        if original and original is list:
-            _args = get_args(value)
-            if len(_args) == 0:
-                return False
-
-            if isinstance(_args[0], Struct) or is_class_and_subclass(_args[0], Struct):
-                return True
-    except TypeError:
-        return False
-    return False
-
-
 def clean_string(value: str) -> str:
+    """
+    Cleans the given string by removing any special characters and replacing spaces with underscores.
+
+    Args:
+        value (str): The string to be cleaned.
+
+    Returns:
+        str: The cleaned string.
+    """
     return slugify.slugify(value, separator="_")
 
 
 def is_optional_union(annotation: Any) -> bool:
+    """
+    Checks if the given annotation is an optional Union type.
+
+    Args:
+        annotation (Any): The annotation to check.
+
+    Returns:
+        bool: True if the annotation is an optional Union type, False otherwise.
+    """
     return get_origin(annotation) in UNION_TYPES and type(None) in get_args(annotation)
+
+
+def is_union(annotation: Any) -> bool:
+    """
+    Checks if the given annotation is a Union type.
+
+    Args:
+        annotation (Any): The annotation to check.
+
+    Returns:
+        bool: True if the annotation is a Union type, False otherwise.
+    """
+    return get_origin(annotation) in UNION_TYPES

--- a/tests/openapi/test_openapi_dependencies.py
+++ b/tests/openapi/test_openapi_dependencies.py
@@ -1,0 +1,75 @@
+from typing import Generic, Optional, Type, TypeVar
+
+from pydantic import BaseModel
+
+from esmerald.injector import Inject
+from esmerald.routing.gateways import Gateway
+from esmerald.routing.handlers import get
+from esmerald.testclient import create_client
+
+T = TypeVar("T")
+
+
+class Store(BaseModel, Generic[T]):
+    """Abstract store."""
+
+    model: Type[T]
+
+    def get(self, value_id: str) -> Optional[T]:  # pragma: no cover
+        raise NotImplementedError
+
+
+class Item(BaseModel):
+    name: str
+
+
+class DictStore(Store[Item]):
+    """In-memory store implementation."""
+
+    def get(self, value_id: str) -> Optional[Item]:
+        return None
+
+
+@get("/")
+async def root(store: DictStore) -> Optional[Item]:
+    assert isinstance(store, DictStore)
+    return store.get("0")
+
+
+def get_item_store() -> DictStore:
+    return DictStore(model=Item)  # type: ignore
+
+
+def test_generic_model_injection() -> None:
+    with create_client(
+        routes=[Gateway(path="/", handler=root)],
+        dependencies={"store": Inject(get_item_store, use_cache=True)},
+    ) as client:
+        response = client.get("/openapi.json")
+
+        assert response.json() == {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Esmerald",
+                "summary": "Esmerald application",
+                "description": "Highly scalable, performant, easy to learn and for every application.",
+                "contact": {"name": "admin", "email": "admin@myapp.com"},
+                "version": client.app.version,
+            },
+            "servers": [{"url": "/"}],
+            "paths": {
+                "/": {
+                    "get": {
+                        "summary": "Root",
+                        "operationId": "root__get",
+                        "responses": {
+                            "200": {
+                                "description": "Successful response",
+                                "content": {"application/json": {"schema": {"type": "string"}}},
+                            }
+                        },
+                        "deprecated": False,
+                    }
+                }
+            },
+        }

--- a/tests/openapi/test_openapi_query_params.py
+++ b/tests/openapi/test_openapi_query_params.py
@@ -1,0 +1,130 @@
+from typing import Dict
+
+from pydantic import BaseModel
+
+from esmerald import Esmerald, Gateway, get
+from esmerald.openapi.datastructures import OpenAPIResponse
+from esmerald.testclient import EsmeraldTestClient
+from tests.settings import TestSettings
+
+
+class PydanticError(BaseModel):
+    detail: str
+    code: int
+
+
+@get(
+    "/bar",
+    tags=["bar"],
+    responses={200: OpenAPIResponse(model=PydanticError, description="Pydantic response")},
+)
+async def bar(name: str) -> Dict[str, str]:
+    return {"hello": "world"}
+
+
+app = Esmerald(
+    routes=[Gateway(handler=bar)],
+    enable_openapi=True,
+    tags=["test"],
+    settings_module=TestSettings,
+    contact={"name": "esmerald", "email": "esmerald@esmeral.dev"},
+)
+
+
+client = EsmeraldTestClient(app)
+
+
+def test_openapi_query_params(test_client_factory):
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+
+    assert response.json() == {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "Esmerald",
+            "summary": "Esmerald application",
+            "description": "Highly scalable, performant, easy to learn and for every application.",
+            "contact": {"name": "esmerald", "email": "esmerald@esmeral.dev"},
+            "version": client.app.version,
+        },
+        "servers": [{"url": "/"}],
+        "paths": {
+            "/bar": {
+                "get": {
+                    "tags": ["test", "bar"],
+                    "summary": "Bar",
+                    "operationId": "bar_bar_get",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "in": "query",
+                            "required": True,
+                            "deprecated": False,
+                            "allowEmptyValue": False,
+                            "allowReserved": False,
+                            "schema": {"type": "string", "title": "Name"},
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Pydantic response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/PydanticError"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                                }
+                            },
+                        },
+                    },
+                    "deprecated": False,
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "properties": {
+                        "detail": {
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                            "type": "array",
+                            "title": "Detail",
+                        }
+                    },
+                    "type": "object",
+                    "title": "HTTPValidationError",
+                },
+                "PydanticError": {
+                    "properties": {
+                        "detail": {"type": "string", "title": "Detail"},
+                        "code": {"type": "integer", "title": "Code"},
+                    },
+                    "type": "object",
+                    "required": ["detail", "code"],
+                    "title": "PydanticError",
+                },
+                "ValidationError": {
+                    "properties": {
+                        "loc": {
+                            "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+                            "type": "array",
+                            "title": "Location",
+                        },
+                        "msg": {"type": "string", "title": "Message"},
+                        "type": {"type": "string", "title": "Error Type"},
+                    },
+                    "type": "object",
+                    "required": ["loc", "msg", "type"],
+                    "title": "ValidationError",
+                },
+            }
+        },
+        "tags": ["test"],
+    }

--- a/tests/openapi/test_openapi_query_params_optional.py
+++ b/tests/openapi/test_openapi_query_params_optional.py
@@ -1,0 +1,133 @@
+from typing import Dict, Optional
+
+from pydantic import BaseModel
+
+from esmerald import Esmerald, Gateway, get
+from esmerald.openapi.datastructures import OpenAPIResponse
+from esmerald.testclient import EsmeraldTestClient
+from tests.settings import TestSettings
+
+
+class PydanticError(BaseModel):
+    detail: str
+    code: int
+
+
+@get(
+    "/bar",
+    tags=["bar"],
+    responses={200: OpenAPIResponse(model=PydanticError, description="Pydantic response")},
+)
+async def bar(name: Optional[str]) -> Dict[str, str]:
+    return {"hello": "world"}
+
+
+app = Esmerald(
+    routes=[Gateway(handler=bar)],
+    enable_openapi=True,
+    tags=["test"],
+    settings_module=TestSettings,
+    contact={"name": "esmerald", "email": "esmerald@esmeral.dev"},
+)
+
+
+client = EsmeraldTestClient(app)
+
+
+def test_openapi_query_params_optional(test_client_factory):
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+
+    assert response.json() == {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "Esmerald",
+            "summary": "Esmerald application",
+            "description": "Highly scalable, performant, easy to learn and for every application.",
+            "contact": {"name": "esmerald", "email": "esmerald@esmeral.dev"},
+            "version": client.app.version,
+        },
+        "servers": [{"url": "/"}],
+        "paths": {
+            "/bar": {
+                "get": {
+                    "tags": ["test", "bar"],
+                    "summary": "Bar",
+                    "operationId": "bar_bar_get",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "in": "query",
+                            "required": False,
+                            "deprecated": False,
+                            "allowEmptyValue": False,
+                            "allowReserved": False,
+                            "schema": {
+                                "anyOf": [{"type": "string"}, {"type": "null"}],
+                                "title": "Name",
+                            },
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Pydantic response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/PydanticError"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                                }
+                            },
+                        },
+                    },
+                    "deprecated": False,
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "properties": {
+                        "detail": {
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                            "type": "array",
+                            "title": "Detail",
+                        }
+                    },
+                    "type": "object",
+                    "title": "HTTPValidationError",
+                },
+                "PydanticError": {
+                    "properties": {
+                        "detail": {"type": "string", "title": "Detail"},
+                        "code": {"type": "integer", "title": "Code"},
+                    },
+                    "type": "object",
+                    "required": ["detail", "code"],
+                    "title": "PydanticError",
+                },
+                "ValidationError": {
+                    "properties": {
+                        "loc": {
+                            "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+                            "type": "array",
+                            "title": "Location",
+                        },
+                        "msg": {"type": "string", "title": "Message"},
+                        "type": {"type": "string", "title": "Error Type"},
+                    },
+                    "type": "object",
+                    "required": ["loc", "msg", "type"],
+                    "title": "ValidationError",
+                },
+            }
+        },
+        "tags": ["test"],
+    }

--- a/tests/openapi/test_openapi_query_params_union.py
+++ b/tests/openapi/test_openapi_query_params_union.py
@@ -1,0 +1,137 @@
+from typing import Dict, Union
+
+from pydantic import BaseModel
+
+from esmerald import Esmerald, Gateway, get
+from esmerald.openapi.datastructures import OpenAPIResponse
+from esmerald.testclient import EsmeraldTestClient
+from tests.settings import TestSettings
+
+
+class PydanticError(BaseModel):
+    detail: str
+    code: int
+
+
+@get(
+    "/bar",
+    tags=["bar"],
+    responses={200: OpenAPIResponse(model=PydanticError, description="Pydantic response")},
+)
+async def bar(name: Union[str, int, None]) -> Dict[str, str]:
+    return {"hello": "world"}
+
+
+app = Esmerald(
+    routes=[Gateway(handler=bar)],
+    enable_openapi=True,
+    tags=["test"],
+    settings_module=TestSettings,
+    contact={"name": "esmerald", "email": "esmerald@esmeral.dev"},
+)
+
+
+client = EsmeraldTestClient(app)
+
+
+def test_openapi_query_params_optional(test_client_factory):
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+
+    assert response.json() == {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "Esmerald",
+            "summary": "Esmerald application",
+            "description": "Highly scalable, performant, easy to learn and for every application.",
+            "contact": {"name": "esmerald", "email": "esmerald@esmeral.dev"},
+            "version": client.app.version,
+        },
+        "servers": [{"url": "/"}],
+        "paths": {
+            "/bar": {
+                "get": {
+                    "tags": ["test", "bar"],
+                    "summary": "Bar",
+                    "operationId": "bar_bar_get",
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "in": "query",
+                            "required": False,
+                            "deprecated": False,
+                            "allowEmptyValue": False,
+                            "allowReserved": False,
+                            "schema": {
+                                "anyOf": [
+                                    {"type": "string"},
+                                    {"type": "integer"},
+                                    {"type": "null"},
+                                ],
+                                "title": "Name",
+                            },
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Pydantic response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/PydanticError"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                                }
+                            },
+                        },
+                    },
+                    "deprecated": False,
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "properties": {
+                        "detail": {
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                            "type": "array",
+                            "title": "Detail",
+                        }
+                    },
+                    "type": "object",
+                    "title": "HTTPValidationError",
+                },
+                "PydanticError": {
+                    "properties": {
+                        "detail": {"type": "string", "title": "Detail"},
+                        "code": {"type": "integer", "title": "Code"},
+                    },
+                    "type": "object",
+                    "required": ["detail", "code"],
+                    "title": "PydanticError",
+                },
+                "ValidationError": {
+                    "properties": {
+                        "loc": {
+                            "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+                            "type": "array",
+                            "title": "Location",
+                        },
+                        "msg": {"type": "string", "title": "Message"},
+                        "type": {"type": "string", "title": "Error Type"},
+                    },
+                    "type": "object",
+                    "required": ["loc", "msg", "type"],
+                    "title": "ValidationError",
+                },
+            }
+        },
+        "tags": ["test"],
+    }

--- a/tests/openapi/test_openapi_query_params_union.py
+++ b/tests/openapi/test_openapi_query_params_union.py
@@ -18,7 +18,7 @@ class PydanticError(BaseModel):
     tags=["bar"],
     responses={200: OpenAPIResponse(model=PydanticError, description="Pydantic response")},
 )
-async def bar(name: Union[str, int, None]) -> Dict[str, str]:
+async def bar(name: Union[str, int]) -> Dict[str, str]:
     return {"hello": "world"}
 
 
@@ -59,16 +59,12 @@ def test_openapi_query_params_optional(test_client_factory):
                         {
                             "name": "name",
                             "in": "query",
-                            "required": False,
+                            "required": True,
                             "deprecated": False,
                             "allowEmptyValue": False,
                             "allowReserved": False,
                             "schema": {
-                                "anyOf": [
-                                    {"type": "string"},
-                                    {"type": "integer"},
-                                    {"type": "null"},
-                                ],
+                                "anyOf": [{"type": "string"}, {"type": "integer"}],
                                 "title": "Name",
                             },
                         }

--- a/tests/routing/test_syntax_enum.py
+++ b/tests/routing/test_syntax_enum.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+from pydantic import __version__
+
+from esmerald import Gateway, JSONResponse, get
+from esmerald.testclient import create_client
+
+pydantic_version = __version__[:3]
+
+
+class ItemType(str, Enum):
+    sold = "sold"
+    bought = "bought"
+
+
+@get("/item/<item_type>")
+async def item(item_type: ItemType) -> JSONResponse:
+    return JSONResponse({"item_type": item_type})
+
+
+def test_syntax():
+    with create_client(routes=[Gateway(handler=item)]) as client:
+
+        response = client.get("/item/sold")
+        assert response.json() == {"item_type": "sold"}
+
+
+def test_syntax_fail():
+    with create_client(routes=[Gateway(handler=item)]) as client:
+
+        response = client.get("/item/test")
+
+        assert response.status_code == 400
+
+        assert response.json() == {
+            "detail": "Validation failed for http://testserver/item/test with method GET.",
+            "errors": [
+                {
+                    "type": "enum",
+                    "loc": ["item_type"],
+                    "msg": "Input should be 'sold' or 'bought'",
+                    "input": "test",
+                    "ctx": {"expected": "'sold' or 'bought'"},
+                    "url": f"https://errors.pydantic.dev/{pydantic_version}/v/enum",
+                }
+            ],
+        }

--- a/tests/routing/test_syntax_param.py
+++ b/tests/routing/test_syntax_param.py
@@ -1,0 +1,22 @@
+from esmerald import Gateway, JSONResponse, get
+from esmerald.testclient import create_client
+
+
+@get("/users/<user_id>")
+async def user(user_id: str) -> JSONResponse:
+    return JSONResponse({"user_id": user_id})
+
+
+@get("/products/<product_id:int>")
+async def product(product_id: int) -> JSONResponse:
+    return JSONResponse({"product_id": product_id})
+
+
+def test_syntax():
+    with create_client(routes=[Gateway(handler=user), Gateway(handler=product)]) as client:
+
+        response = client.get("/users/1")
+        assert response.json() == {"user_id": "1"}
+
+        response = client.get("/products/1")
+        assert response.json() == {"product_id": 1}


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

This addresses a regression introduced when we moved to Encoders where the query params when declared should be displayed in the OpenAPI documentation.

Adds missing documents (somehow this was missed....) and extra tests for various features.