### PR TITLE
Adaptions for asyncz>=0.11, fix typo

### DIFF
--- a/docs_src/configurations/openapi/apiview.py
+++ b/docs_src/configurations/openapi/apiview.py
@@ -4,5 +4,5 @@ app = Esmerald(
     routes=[...],
     docs_url="/another-url/swagger",
     redoc_url="/another-url/redoc",
-    redoc_url="/another-url/stoplight",
+    stoplight_url="/another-url/stoplight",
 )

--- a/esmerald/contrib/schedulers/asyncz/config.py
+++ b/esmerald/contrib/schedulers/asyncz/config.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Type, Union
 from asyncz.schedulers import AsyncIOScheduler
 from asyncz.schedulers.types import SchedulerType
 from asyncz.triggers.types import TriggerType
-from asyncz.typing import UndefinedType, undefined
+from asyncz.typing import Undefined, undefined
 
 from esmerald.conf import settings
 from esmerald.contrib.schedulers.base import SchedulerConfig
@@ -148,12 +148,12 @@ class Task:
         name: Union[str, None] = None,
         trigger: Union[TriggerType, None] = None,
         id: Union[str, None] = None,
-        mistrigger_grace_time: Union[int, UndefinedType, None] = undefined,
-        coalesce: Union[bool, UndefinedType] = undefined,
-        max_instances: Union[int, UndefinedType, None] = undefined,
-        next_run_time: Union[datetime, str, UndefinedType, None] = undefined,
-        store: str = "default",
-        executor: str = "default",
+        mistrigger_grace_time: Union[int, Undefined, None] = undefined,
+        coalesce: Union[bool, Undefined] = undefined,
+        max_instances: Union[int, Undefined, None] = undefined,
+        next_run_time: Union[datetime, str, Undefined, None] = undefined,
+        store: Union[str, None] = None,
+        executor: Union[str, None] = None,
         replace_existing: bool = False,
         args: Union[Any, None] = None,
         kwargs: Union[Dict[str, Any], None] = None,

--- a/esmerald/contrib/schedulers/asyncz/decorator.py
+++ b/esmerald/contrib/schedulers/asyncz/decorator.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional, Union, cast
 
 from asyncz.triggers.types import TriggerType
-from asyncz.typing import UndefinedType, undefined
+from asyncz.typing import Undefined, undefined
 
 from esmerald.contrib.schedulers.asyncz.config import Task
 
@@ -12,12 +12,12 @@ def scheduler(
     name: Optional[str] = None,
     trigger: Optional[TriggerType] = None,
     id: Optional[str] = None,
-    mistrigger_grace_time: Union[int, UndefinedType, None] = undefined,
-    coalesce: Union[bool, UndefinedType] = undefined,
-    max_instances: Union[int, UndefinedType, None] = undefined,
-    next_run_time: Union[datetime, str, UndefinedType, None] = undefined,
-    store: Optional[str] = "default",
-    executor: Optional[str] = "default",
+    mistrigger_grace_time: Union[int, Undefined, None] = undefined,
+    coalesce: Union[bool, Undefined] = undefined,
+    max_instances: Union[int, Undefined, None] = undefined,
+    next_run_time: Union[datetime, str, Undefined, None] = undefined,
+    store: Union[str, None] = None,
+    executor: Union[str, None] = None,
     replace_existing: bool = True,
     extra_args: Optional[Any] = None,
     extra_kwargs: Optional[Dict[str, Any]] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ dev = [
 templates = ["mako>=1.2.4,<2.0.0"]
 jwt = ["passlib==1.7.4", "python-jose>=3.3.0,<4"]
 encoders = ["ujson>=5.7.0,<6"]
-schedulers = ["asyncz>=0.10.0"]
+schedulers = ["asyncz>=0.11.0"]
 all = [
     "esmerald[test,dev,templates,jwt,encoders,schedulers]",
     "ipython",

--- a/tests/schedulers/asyncz/test_scheduler.py
+++ b/tests/schedulers/asyncz/test_scheduler.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from asyncz.executors.base import BaseExecutor
 from asyncz.schedulers import AsyncIOScheduler
-from asyncz.schedulers.base import BaseScheduler
+from asyncz.schedulers.base import BaseScheduler, default_loggers_class
 from asyncz.schedulers.datastructures import TaskDefaultStruct
 from asyncz.stores.base import BaseStore
 from asyncz.tasks.types import TaskType
@@ -113,6 +113,8 @@ def scheduler_class(monkeypatch):
     # by patching out _setup task_defaults are not initialized anymore
     scheduler_class.task_defaults = TaskDefaultStruct()
     scheduler_class.timezone = timezone.utc
+    scheduler_class.loggers = default_loggers_class()
+    scheduler_class.logger_name = "asyncz.schedulers"
     return scheduler_class
 
 


### PR DESCRIPTION
Changes:

- fix compatibility with asyncz>=0.11 (tests)
- use new add_task signature
- fix typo in docs_src

Note: the former versions of esmerald will still work with asyncz>=0.11 but we could not unset store and executor and used a legacy shim for Undefined.

### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.
