### PR TITLE
Fix summary lookup in OpenAPI handler routing

### DIFF
--- a/esmerald/openapi/openapi.py
+++ b/esmerald/openapi/openapi.py
@@ -144,7 +144,7 @@ def get_openapi_operation(
     operation.tags = route.handler.get_handler_tags()
 
     if route.handler.summary:
-        operation.summary = route.summary
+        operation.summary = route.handler.summary
     else:
         operation.summary = route.handler.name.replace("_", " ").replace("-", " ").title()
 


### PR DESCRIPTION
### Summary or description

Addresses the way of capturing the summary from the handler, properly.
