### PR TITLE
fix shadowing warning of help in BaseDirective

### DIFF
--- a/esmerald/core/directives/base.py
+++ b/esmerald/core/directives/base.py
@@ -8,9 +8,7 @@ printer = Print()
 
 
 class BaseDirective(ArbitraryExtraBaseModel, LilyaBaseDirective):
-    """The base class from which all directrives derive"""
-
-    help: str = ""
+    """The base class from which all directives derive."""
 
     def get_version(self) -> str:
         """


### PR DESCRIPTION
help is already defined in the lilya BaseDirective. Adding it in esmerald causes a shadowing warning. 