### PR TITLE
stop ignoring the warnings despite there are plenty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,8 +173,8 @@ features = ["all", "testing"]
 
 [tool.hatch.envs.test.scripts]
 # needs docker services running
-test = "hatch test -- {args} --disable-warnings"
-test_man = "hatch test -- {args} -s -vv --disable-warnings"
+test = "hatch test -- {args}"
+test_man = "hatch test -- {args} -s -vv"
 coverage = "hatch test -- --cov=esmerald --cov=tests --cov-report=term-missing:skip-covered --cov-report=html tests {args}"
 check_types = "mypy -p esmerald"
 


### PR DESCRIPTION
Currently via `--disable-warnings` warnings are ignored.
This hides away some problems so remove the flag despite the plenty warnings (we will fix them one by one).
