### PR TITLE
Mako warning & documentation how to use templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,6 @@ $ pip install esmerald[schedulers]
 $ pip install esmerald[jwt]
 ```
 
-**Support for ORJSON and UJSON**:
-
-```shell
-$ pip install esmerald[encoders]
-```
-
 **If you want to use the esmerald testing client**:
 
 ```shell
@@ -359,11 +353,11 @@ For a classic, direct, one file single approach.
 **In a nutshell**:
 
 ```python title='src/app.py'
-from esmerald import Esmerald, get, status, Request, UJSONResponse, Gateway, WebSocketGateway, Websocket
+from esmerald import Esmerald, get, status, Request, ORJSONResponse, Gateway, WebSocketGateway, Websocket
 
 @get(status_code=status.HTTP_200_OK)
-async def home() -> UJSONResponse:
-    return UJSONResponse({
+async def home() -> ORJSONResponse:
+    return ORJSONResponse({
         "detail": "Hello world"
     })
 

--- a/README.md
+++ b/README.md
@@ -81,14 +81,6 @@ $ pip install uvicorn
 
 If you want install esmerald with specifics:
 
-**Support for template system such as jinja2 and mako**:
-
-```shell
-$ pip install esmerald[templates]
-```
-
-Warning: Mako is quite limited as template engine here. This will change in future.
-
 **Support for the internal scheduler**:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ If you want install esmerald with specifics:
 $ pip install esmerald[templates]
 ```
 
+Warning: Mako is quite limited as template engine here. This will change in future.
+
 **Support for the internal scheduler**:
 
 ```shell

--- a/docs/en/docs/configurations/template.md
+++ b/docs/en/docs/configurations/template.md
@@ -20,15 +20,7 @@ You are free to build your own and pass it to the `TemplateConfig`. This way you
     You will notice the name of the parameters in the `TemplateConfig` match maority of the jinja2 implementation.
 
 !!! Warning
-    The mako engine has a quite limited integration. This will change in future.
-
-## Requirements
-
-This section requires `jinja` or `mako` to be installed. You can do it so by running:
-
-```shell
-$ pip install esmerald[templates]
-```
+    The `Mako` engine has a quite limited integration. This will change in future.
 
 ## TemplateConfig and application
 
@@ -72,3 +64,5 @@ you can do something like this:
 
 Simply return `Template` (of esmerald) not `TemplateResponse` with a `name` parameter pointing to the relative path of the template.
 You can pass extra data via setting the `context` parameter to a dictionary containing the extra data.
+
+To select the return type (txt, html) you need to name the files: `foo.html.jinja`.

--- a/docs/en/docs/configurations/template.md
+++ b/docs/en/docs/configurations/template.md
@@ -20,7 +20,7 @@ You are free to build your own and pass it to the `TemplateConfig`. This way you
     You will notice the name of the parameters in the `TemplateConfig` match maority of the jinja2 implementation.
 
 !!! Warning
-    The `Mako` engine has a limited integration. This will change in the future.
+    The `Mako` engine has a limited integration within Esmerald. This will change in the future.
 
 ## TemplateConfig and application
 

--- a/docs/en/docs/configurations/template.md
+++ b/docs/en/docs/configurations/template.md
@@ -19,6 +19,9 @@ You are free to build your own and pass it to the `TemplateConfig`. This way you
 
     You will notice the name of the parameters in the `TemplateConfig` match maority of the jinja2 implementation.
 
+!!! Warning
+    The mako engine has a quite limited integration. This will change in future.
+
 ## Requirements
 
 This section requires `jinja` or `mako` to be installed. You can do it so by running:
@@ -64,3 +67,8 @@ you can do something like this:
 ```jinja
 {!> ../../../docs_src/_shared/jinja.html!}
 ```
+
+## How to use
+
+Simply return `Template` (of esmerald) not `TemplateResponse` with a `name` parameter pointing to the relative path of the template.
+You can pass extra data via setting the `context` parameter to a dictionary containing the extra data.

--- a/docs/en/docs/configurations/template.md
+++ b/docs/en/docs/configurations/template.md
@@ -20,7 +20,7 @@ You are free to build your own and pass it to the `TemplateConfig`. This way you
     You will notice the name of the parameters in the `TemplateConfig` match maority of the jinja2 implementation.
 
 !!! Warning
-    The `Mako` engine has a quite limited integration. This will change in future.
+    The `Mako` engine has a limited integration. This will change in the future.
 
 ## TemplateConfig and application
 

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -88,6 +88,9 @@ If you want install esmerald with specifics:
 $ pip install esmerald[templates]
 ```
 
+!!! Warning
+    Mako is quite limited as template engine here. This will change in future.
+
 **Support for the internal scheduler**:
 
 ```shell

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -80,17 +80,6 @@ up to you.
 $ pip install uvicorn
 ```
 
-If you want install esmerald with specifics:
-
-**Support for template system such as jinja2 and mako**:
-
-```shell
-$ pip install esmerald[templates]
-```
-
-!!! Warning
-    Mako is quite limited as template engine here. This will change in future.
-
 **Support for the internal scheduler**:
 
 ```shell
@@ -101,12 +90,6 @@ $ pip install esmerald[schedulers]
 
 ```shell
 $ pip install esmerald[jwt]
-```
-
-**Support for ORJSON and UJSON**:
-
-```shell
-$ pip install esmerald[encoders]
 ```
 
 **If you want to use the esmerald testing client**:

--- a/docs/en/docs/responses.md
+++ b/docs/en/docs/responses.md
@@ -31,7 +31,7 @@ Some responses use extra dependencies, such as [UJSON](#ujson) and [OrJSON](#orj
 responses, you need to install:
 
 ```shell
-$ pip install esmerald[encoders]
+$ pip install ujson orjson
 ```
 
 This will allow you to use the [OrJSON](#orjson) and [UJSON](#ujson) as well as the

--- a/esmerald/config/template.py
+++ b/esmerald/config/template.py
@@ -13,11 +13,6 @@ class TemplateConfig(BaseModel):
 
     This configuration is a simple set of configurations that when passed enables the template engine.
 
-    !!! Note
-        You might need to install the template engine before
-        using this. You can always run
-        `pip install esmerald[templates]` to help you out.
-
     **Example**
 
     ```python

--- a/esmerald/datastructures/encoders.py
+++ b/esmerald/datastructures/encoders.py
@@ -19,7 +19,7 @@ except ImportError:  # pragma: no cover
     UJSONResponse = None  # type: ignore
 
 
-class OrJSON(ResponseContainer[ORJSONResponse]):
+class ORJSON(ResponseContainer[ORJSONResponse]):
     content: Annotated[
         Optional[Dict[str, Any]],
         Doc(
@@ -75,6 +75,9 @@ class OrJSON(ResponseContainer[ORJSONResponse]):
             media_type=media_type,
             background=self.background,
         )
+
+
+OrJSON = ORJSON
 
 
 class UJSON(ResponseContainer[UJSONResponse]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,17 +96,17 @@ dev = [
     "uvicorn[standard]>=0.24.0",
 ]
 
-templates = ["mako>=1.2.4,<2.0.0"]
 jwt = ["passlib==1.7.4", "python-jose>=3.3.0,<4"]
-encoders = ["ujson>=5.7.0,<6"]
 schedulers = ["asyncz>=0.11.0"]
 all = [
-    "esmerald[test,dev,templates,jwt,encoders,schedulers]",
+    "esmerald[test,dev,jwt,schedulers]",
     "ipython",
     "ptpython",
     "a2wsgi",
 ]
 testing = [
+    "mako>=1.2.4,<2.0.0",
+    "ujson>=5.7.0,<6",
     "anyio[trio]>=3.6.2,<5.0.0",
     "brotli>=1.0.9,<2.0.0",
     "edgy[postgres]>=0.16.0",

--- a/tests/test_datastructures_response.py
+++ b/tests/test_datastructures_response.py
@@ -2,11 +2,11 @@ import pytest
 
 from esmerald import Gateway, get, status
 from esmerald.datastructures import JSON
-from esmerald.datastructures.encoders import UJSON, OrJSON
+from esmerald.datastructures.encoders import ORJSON, UJSON
 from esmerald.testclient import create_client
 
 
-@pytest.mark.parametrize("response", [JSON, OrJSON, UJSON])
+@pytest.mark.parametrize("response", [JSON, ORJSON, UJSON])
 def test_json_datastructure(response, test_client_factory):
     @get()
     async def home() -> response:
@@ -19,7 +19,7 @@ def test_json_datastructure(response, test_client_factory):
         assert response.json()["detail"] == "using JSON structure"
 
 
-@pytest.mark.parametrize("response", [JSON, OrJSON, UJSON])
+@pytest.mark.parametrize("response", [JSON, ORJSON, UJSON])
 def test_json_datastructure_with_different_status_code(response, test_client_factory):
     @get()
     async def home_two() -> response:
@@ -32,7 +32,7 @@ def test_json_datastructure_with_different_status_code(response, test_client_fac
         assert response.json()["detail"] == "using JSON structure"
 
 
-@pytest.mark.parametrize("response", [JSON, OrJSON, UJSON])
+@pytest.mark.parametrize("response", [JSON, ORJSON, UJSON])
 def test_json_datastructure_with_different_status_code_on_handler(response, test_client_factory):
     @get(status_code=status.HTTP_202_ACCEPTED)
     async def home_three() -> response:
@@ -45,7 +45,7 @@ def test_json_datastructure_with_different_status_code_on_handler(response, test
         assert response.json()["detail"] == "using JSON structure"
 
 
-@pytest.mark.parametrize("response", [JSON, OrJSON, UJSON])
+@pytest.mark.parametrize("response", [JSON, ORJSON, UJSON])
 def test_json_datastructure_with_different_status_code_on_handler_two(
     response, test_client_factory
 ):


### PR DESCRIPTION
Changes:
- warn that mako has a limited integration
- document how to use templates
- remove extras encoders, template. We decided already and have a hard dependency.
- rename OrJSON to ORJSON but keep old name as alias