### PR TITLE
runserver requires esmerald app instance

### DIFF
--- a/esmerald/core/directives/operations/runserver.py
+++ b/esmerald/core/directives/operations/runserver.py
@@ -103,15 +103,20 @@ def runserver(
     except ImportError:
         raise DirectiveError(detail="Uvicorn needs to be installed to run Esmerald.") from None
 
+    server_environment: str = ""
+    if os.environ.get("ESMERALD_SETTINGS_MODULE"):
+        from esmerald.conf import settings as esmerald_settings
+
+        server_environment = f"{esmerald_settings.environment} "
     app = env.app
     message = terminal.write_info(
-        f"Starting {app.settings.environment} server @ {host}",
+        f"Starting {server_environment}server @ {host}",
         colour=OutputColour.BRIGHT_CYAN,
     )
     terminal.rule(message, align="center")
 
-    if settings is not None:
-        custom_message = f"'{os.environ.get('ESMERALD_SETTINGS_MODULE')}'"
+    if os.environ.get("ESMERALD_SETTINGS_MODULE"):
+        custom_message = f"'{os.environ['ESMERALD_SETTINGS_MODULE']}'"
         terminal.rule(custom_message, align="center")
 
     if debug:


### PR DESCRIPTION
### Checklist

- [ ] The code has 100% test coverage. No extra test added, small change
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Changes:
- Remove dependency of app being an esmerald instance for runserver
- Check environment instead of settings variable for esmerald settings
