### PR TITLE
fix: middleware example from edgy to jwt.md

### DIFF
--- a/docs/en/docs/configurations/jwt.md
+++ b/docs/en/docs/configurations/jwt.md
@@ -24,8 +24,8 @@ To use the JWTConfig with a middleware.
 ```
 
 !!! info
-    The example uses a supported [JWTAuthMiddleware](../databases/saffier/middleware.md#jwtauthmiddleware)
-    from Esmerald with Saffier ORM.
+    The example uses a supported [JWTAuthMiddleware](../databases/edgy/middleware.md#jwtauthmiddleware)
+    from Esmerald with Edgy ORM.
 
 ## Parameters
 
@@ -179,9 +179,9 @@ in dictating which type of token is being validated and sent.
 
 The `access_token` is sent via `headers` **as it should** and the `refresh_token` is sent via `POST`.
 
-#### The views
+#### The controllers
 
-Now it is time to assemble everything in the views where we will have:
+Now it is time to assemble everything in the controllers where we will have:
 
 * `/auth/create` - Endpoint to create the users.
 * `/auth/signin` - Login endpoint for the user.

--- a/docs_src/configurations/jwt/claims/middleware.py
+++ b/docs_src/configurations/jwt/claims/middleware.py
@@ -1,7 +1,7 @@
 from jose import JWSError, JWTError
 
 from esmerald.conf import settings
-from esmerald.contrib.auth.mongoz.middleware import JWTAuthMiddleware as EsmeraldMiddleware
+from esmerald.contrib.auth.edgy.middleware import JWTAuthMiddleware as EsmeraldMiddleware
 from esmerald.exceptions import AuthenticationError, NotAuthorized
 from esmerald.middleware.authentication import AuthResult
 from esmerald.security.jwt.token import Token

--- a/docs_src/configurations/jwt/settings.py
+++ b/docs_src/configurations/jwt/settings.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, List
 
 from esmerald import EsmeraldAPISettings
 from esmerald.config.jwt import JWTConfig
-from esmerald.contrib.auth.saffier.middleware import JWTAuthMiddleware
+from esmerald.contrib.auth.edgy.middleware import JWTAuthMiddleware
 from lilya._internal._module_loading import import_string
 from lilya.middleware import DefineMiddleware as LilyaMiddleware
 


### PR DESCRIPTION
### Checklist

- [ ] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description
Changed imports to use Edgy so there would be no inconsistencies in the examples.