### PR TITLE
allow passing handlers to routes

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -7,10 +7,6 @@ hide:
 
 ## Unreleased
 
-### Added
-
-- Allow passing HTTP/WebSocket handlers directly to routes. They are automatically wrapped in Gateways-
-
 ### Changed
 
 - Pluggables can now receive plain Extensions and Extension classes.
@@ -18,6 +14,7 @@ hide:
     - Breaking: The `pluggables` attribute and parameter are now renamed to `extensions`. The old name is still available but deprecated.
     - Breaking: The `add_pluggable` method is now renamed to `add_extension`. The old name is still available but deprecated.
     - The documentation will refer now to extensions with `Pluggable` as a setup wrapper.
+- Allow passing HTTP/WebSocket handlers directly to routes. They are automatically wrapped in Gateways-
 
 ## 3.4.4
 

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -15,6 +15,7 @@ hide:
     - Breaking: The `add_pluggable` method is now renamed to `add_extension`. The old name is still available but deprecated.
     - The documentation will refer now to extensions with `Pluggable` as a setup wrapper.
 - Allow passing HTTP/WebSocket handlers directly to routes. They are automatically wrapped in Gateways-
+- Allow passing HTTP/WebSocket handlers directly to routes as alternative to defining a Gateway/WebsocketGateway.
 
 ## 3.4.4
 

--- a/docs/en/docs/routing/routes.md
+++ b/docs/en/docs/routing/routes.md
@@ -16,14 +16,14 @@ different APIs and systems, so Esmerald created its own.
 A Gateway is an extension of the Route, really, but adds its own logic and handling capabilities, as well as its own
 validations, without compromising the core.
 
-It is automatically added when just passing an HTTP/Websocket handler to routes.
+When a handler is passed instead of a Gateway/WebsocketGateway, it will be automatically mapped to the corresponding wrapper and added to the routes.
 
 ### Gateway and application
 
 In simple terms, a Gateway is not a direct route but instead is a "wrapper" of a [handler](./handlers.md)
 and maps that same handler with the application routing system.
 
-This allows overwriting options of the handler route specific.
+This allows overwriting options of the specific handler route.
 If not required, you can just pass the handler, it is automatically wrapped in a plain Gateway.
 
 #### Parameters
@@ -41,7 +41,7 @@ All the parameters and defaults are available in the [Gateway Reference](../refe
 Same principle as [Gateway](#gateway) with one particularity. Due to the nature of Lilya and websockets we
 decided not to interfere (for now) with what already works and therefore the only supported websockets are `async`.
 
-This allows overwriting options of the WebsocketHandler route specific.
+This allows overwriting options of the specific WebsocketHandler route.
 If not required, you can just pass the handler, it is automatically wrapped in a plain WebSocketGateway.
 
 ### WebSocketGateway and application

--- a/docs/en/docs/routing/routes.md
+++ b/docs/en/docs/routing/routes.md
@@ -23,6 +23,9 @@ It is automatically added when just passing an HTTP/Websocket handler to routes.
 In simple terms, a Gateway is not a direct route but instead is a "wrapper" of a [handler](./handlers.md)
 and maps that same handler with the application routing system.
 
+This allows overwriting options of the handler route specific.
+If not required, you can just pass the handler, it is automatically wrapped in a plain Gateway.
+
 #### Parameters
 
 All the parameters and defaults are available in the [Gateway Reference](../references/routing/gateway.md).
@@ -37,6 +40,9 @@ All the parameters and defaults are available in the [Gateway Reference](../refe
 
 Same principle as [Gateway](#gateway) with one particularity. Due to the nature of Lilya and websockets we
 decided not to interfere (for now) with what already works and therefore the only supported websockets are `async`.
+
+This allows overwriting options of the WebsocketHandler route specific.
+If not required, you can just pass the handler, it is automatically wrapped in a plain WebSocketGateway.
 
 ### WebSocketGateway and application
 

--- a/esmerald/routing/router.py
+++ b/esmerald/routing/router.py
@@ -488,7 +488,7 @@ class BaseRouter(LilyaRouter):
         for route in routes or []:
             if isinstance(route, WebhookHandler):
                 # WebhookHandler is a subclass of HTTPHandler, make sure to not upgrade it
-                pass
+                ...
             elif isinstance(route, HTTPHandler):
                 # if using add_route, we would enter a completely different code path with a not fully initialized router
                 route = Gateway(handler=route)
@@ -2915,7 +2915,7 @@ class Include(LilyaInclude):
         for route in routes:  # pragma: no cover
             if isinstance(route, WebhookHandler):
                 # fail later, a WebhookHandler is subclass of HTTPHandler, so pass down
-                pass
+                ...
             elif isinstance(route, HTTPHandler):
                 # if using add_route, we would enter a completely different code path with a not fully initialized router
                 route = Gateway(handler=route)

--- a/esmerald/routing/router.py
+++ b/esmerald/routing/router.py
@@ -490,10 +490,8 @@ class BaseRouter(LilyaRouter):
                 # WebhookHandler is a subclass of HTTPHandler, make sure to not upgrade it
                 ...
             elif isinstance(route, HTTPHandler):
-                # if using add_route, we would enter a completely different code path with a not fully initialized router
                 route = Gateway(handler=route)
             elif isinstance(route, WebSocketHandler):
-                # if using add_websocket_route, we would enter a completely different code path with a not fully initialized router
                 route = WebSocketGateway(handler=route)
             if not isinstance(
                 route,
@@ -2917,10 +2915,8 @@ class Include(LilyaInclude):
                 # fail later, a WebhookHandler is subclass of HTTPHandler, so pass down
                 ...
             elif isinstance(route, HTTPHandler):
-                # if using add_route, we would enter a completely different code path with a not fully initialized router
                 route = Gateway(handler=route)
             elif isinstance(route, WebSocketHandler):
-                # if using add_websocket_route, we would enter a completely different code path with a not fully initialized router
                 route = WebSocketGateway(handler=route)
 
             if not isinstance(route, (Include, Gateway, WebSocketGateway)):

--- a/esmerald/routing/router.py
+++ b/esmerald/routing/router.py
@@ -542,7 +542,9 @@ class BaseRouter(LilyaRouter):
         self.deprecated = deprecated
         self.security = security or []
 
-        for route in self.routes:
+        # copy routes shallow, fixes bug with tests/dependencies/test_http_handler_dependency_injection.py
+        # routes are modified by validate_root_route_parent
+        for route in list(self.routes):
             self.validate_root_route_parent(route)  # type: ignore
 
         for route in self.routes:

--- a/tests/openapi/test_contact_direct_handler.py
+++ b/tests/openapi/test_contact_direct_handler.py
@@ -1,0 +1,67 @@
+from typing import Dict
+
+from esmerald import Esmerald, Gateway, get
+from esmerald.testclient import EsmeraldTestClient
+from tests.settings import TestSettings
+
+
+@get("/bar")
+async def bar() -> Dict[str, str]:
+    return {"hello": "world"}
+
+
+app = Esmerald(
+    contact={
+        "name": "API Support",
+        "url": "https://www.example.com",
+        "email": "example@example.com",
+    },
+    routes=[bar],
+    enable_openapi=True,
+    settings_module=TestSettings,
+)
+
+
+client = EsmeraldTestClient(app)
+
+
+def test_application(test_client_factory):
+    response = client.get("/bar")
+    assert response.status_code == 200, response.json()
+
+
+def test_openapi_schema(test_client_factory):
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "Esmerald",
+            "summary": "Esmerald application",
+            "description": "Highly scalable, performant, easy to learn and for every application.",
+            "contact": {
+                "name": "API Support",
+                "url": "https://www.example.com/",
+                "email": "example@example.com",
+            },
+            "version": client.app.version,
+        },
+        "servers": [{"url": "/"}],
+        "paths": {
+            "/bar": {
+                "get": {
+                    "summary": "Bar",
+                    "description": "",
+                    "operationId": "bar_bar_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful response",
+                            "content": {"application/json": {"schema": {"type": "string"}}},
+                        }
+                    },
+                    "deprecated": False,
+                }
+            }
+        },
+    }

--- a/tests/openapi/test_contact_direct_handler.py
+++ b/tests/openapi/test_contact_direct_handler.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from esmerald import Esmerald, Gateway, get
+from esmerald import Esmerald, get
 from esmerald.testclient import EsmeraldTestClient
 from tests.settings import TestSettings
 

--- a/tests/openapi/test_include.py
+++ b/tests/openapi/test_include.py
@@ -1,5 +1,6 @@
 from typing import Dict, Union
 
+import pytest
 from pydantic import BaseModel
 
 from esmerald import JSON, Gateway, Include, get
@@ -25,11 +26,12 @@ async def read_item() -> JSON:
     """ """
 
 
-def test_add_include_to_openapi(test_client_factory):
+@pytest.mark.parametrize("route", [Gateway(handler=read_item), read_item])
+def test_add_include_to_openapi(test_client_factory, route):
     with create_client(
         routes=[
             Gateway(handler=read_people),
-            Include("/child", routes=[Gateway(handler=read_item)]),
+            Include("/child", routes=[route]),
         ],
         settings_module=TestSettings,
     ) as client:

--- a/tests/routing/test_include_errors.py
+++ b/tests/routing/test_include_errors.py
@@ -1,11 +1,16 @@
 import pytest
 
-from esmerald import Gateway, ImproperlyConfigured, Include, get
+from esmerald import Gateway, ImproperlyConfigured, Include, WebhookGateway, get, whget
 
 
 @get()
 async def home() -> None:
     """"""
+
+
+@whget("new-event")
+async def new_event() -> bool:
+    return True
 
 
 gateway = Gateway(handler=home)
@@ -34,6 +39,12 @@ def test_raise_error_pattern(arg):
 def test_raise_error_pattern_and_routes():
     with pytest.raises(ImproperlyConfigured):
         Include(pattern="test", routes=[gateway])
+
+
+@pytest.mark.parametrize("arg", [new_event, WebhookGateway(handler=new_event)])
+def test_raise_error_webhooks(arg):
+    with pytest.raises(ImproperlyConfigured):
+        Include(routes=[arg])
 
 
 def test_namespace_include_routes():

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3,10 +3,16 @@ from lilya import status
 
 from esmerald.exceptions import ImproperlyConfigured
 from esmerald.routing.apis.views import APIView
-from esmerald.routing.gateways import Gateway, WebSocketGateway
+from esmerald.routing.gateways import Gateway, WebhookGateway, WebSocketGateway
 from esmerald.routing.handlers import delete, get, post, put, route, websocket
+from esmerald.routing.webhooks import whget
 from esmerald.testclient import create_client
 from esmerald.websockets import WebSocket
+
+
+@whget("new-event")
+async def new_event() -> bool:
+    return True
 
 
 @get(status_code=status.HTTP_202_ACCEPTED)
@@ -55,6 +61,25 @@ def test_add_route_from_router(test_client_factory) -> None:
     """
 
     with create_client(routes=[Gateway(handler=route_one)]) as client:
+        response = client.get("/")
+
+        assert response.json() == {"test": 1}
+        assert response.status_code == status.HTTP_202_ACCEPTED
+
+        client.app.router.add_route("/second", handler=route_two)
+
+        response = client.get("/second")
+
+        assert response.json() == {"test": 2}
+        assert response.status_code == status.HTTP_206_PARTIAL_CONTENT
+
+
+def test_add_route_from_router_direct(test_client_factory) -> None:
+    """
+    Adds a route to the router.
+    """
+
+    with create_client(routes=[route_one]) as client:
         response = client.get("/")
 
         assert response.json() == {"test": 1}
@@ -150,6 +175,28 @@ def test_add_route_multiple_from_application(test_client_factory) -> None:
 
         assert response.json() == {"test": 1}
         assert response.status_code == status.HTTP_202_ACCEPTED
+
+
+@pytest.mark.parametrize("arg", [new_event, WebhookGateway(handler=new_event)])
+def test_raise_exception_on_create_webhook(test_client_factory, arg) -> None:
+    """
+    Raises improperly configured.
+    """
+
+    with pytest.raises(ImproperlyConfigured):
+        with create_client(routes=[arg]):
+            pass
+
+
+@pytest.mark.parametrize("arg", [new_event, WebhookGateway(handler=new_event)])
+def test_raise_exception_on_add_webhook(test_client_factory, arg) -> None:
+    """
+    Raises improperly configured.
+    """
+
+    with create_client(routes=[]) as client:
+        with pytest.raises(ImproperlyConfigured):
+            client.app.add_route("/fooobar", handler=arg)
 
 
 def test_raise_exception_on_add_route(test_client_factory) -> None:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -210,8 +210,16 @@ def test_raise_exception_on_add_route(test_client_factory) -> None:
             client.app.add_route("/one", handler=handler)
 
 
-def test_websocket_handler_gateway_from_router(test_client_factory) -> None:
-    client = create_client(routes=[WebSocketGateway(path="/", handler=simple_websocket_handler)])
+@pytest.mark.parametrize(
+    "arg",
+    [
+        simple_websocket_handler,
+        WebSocketGateway(handler=simple_websocket_handler),
+        WebSocketGateway(path="/", handler=simple_websocket_handler),
+    ],
+)
+def test_websocket_handler_gateway_from_router(test_client_factory, arg) -> None:
+    client = create_client(routes=[arg])
 
     with client.websocket_connect("/") as websocket_client:
         websocket_client.send_json({"data": "esmerald"})
@@ -225,8 +233,16 @@ def test_websocket_handler_gateway_from_router(test_client_factory) -> None:
         assert data
 
 
-def test_websocket_handler_gateway_from_application(test_client_factory) -> None:
-    client = create_client(routes=[WebSocketGateway(path="/", handler=simple_websocket_handler)])
+@pytest.mark.parametrize(
+    "arg",
+    [
+        simple_websocket_handler,
+        WebSocketGateway(handler=simple_websocket_handler),
+        WebSocketGateway(path="/", handler=simple_websocket_handler),
+    ],
+)
+def test_websocket_handler_gateway_from_application(test_client_factory, arg) -> None:
+    client = create_client(routes=[arg])
 
     with client.websocket_connect("/") as websocket_client:
         websocket_client.send_json({"data": "esmerald"})


### PR DESCRIPTION
### Checklist

- [x] The code has 1000% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Changes:
- simplify routing by allowing just passing HTTP/Websocket Handlers to routes
  This matches the add_route behavior.

Note: there are no OpenAPI tests I found using Websockets, so I skipped this. We should add such tests later.