### PR TITLE
Allow overwriting the encoder set / use encoders of requests / more orjson for more speed

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -5,6 +5,14 @@ hide:
 
 # Release Notes
 
+## Unreleased
+
+### Changed
+
+- Use assigned encoders at requests for json_encoder.
+- Allow overwriting the `LILYA_ENCODER_TYPES` for different encoder sets or tests.
+- Use more orjson for encoding requests.
+
 ## 3.5.0
 
 ### Added

--- a/esmerald/responses/base.py
+++ b/esmerald/responses/base.py
@@ -1,3 +1,5 @@
+from functools import partial
+from inspect import isclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -23,10 +25,10 @@ from lilya.responses import (
     Response as LilyaResponse,  # noqa
     StreamingResponse as StreamingResponse,  # noqa
 )
-from orjson import OPT_OMIT_MICROSECONDS, OPT_SERIALIZE_NUMPY, dumps
+from orjson import OPT_OMIT_MICROSECONDS, OPT_SERIALIZE_NUMPY, dumps, loads
 from typing_extensions import Annotated, Doc
 
-from esmerald.encoders import Encoder, json_encoder
+from esmerald.encoders import LILYA_ENCODER_TYPES, Encoder, json_encoder
 from esmerald.enums import MediaType
 from esmerald.exceptions import ImproperlyConfigured
 
@@ -180,9 +182,21 @@ class Response(LilyaResponse, Generic[T]):
 
         Supports all the default encoders from Lilya and custom from Esmerald.
         """
-        return cast(Dict[str, Any], json_encoder(value))
+        return cast(
+            Dict[str, Any], json_encoder(value, json_encode_fn=dumps, post_transform_fn=loads)
+        )
 
     def make_response(self, content: Any) -> Union[bytes, str]:
+        encoders = (
+            (
+                (
+                    *(encoder() if isclass(encoder) else encoder for encoder in self.encoders),
+                    *LILYA_ENCODER_TYPES.get(),
+                )
+            )
+            if self.encoders
+            else None
+        )
         try:
             if (
                 content is None
@@ -195,10 +209,16 @@ class Response(LilyaResponse, Generic[T]):
             ):
                 return b""
             if self.media_type == MediaType.JSON:
-                return dumps(
-                    content,
-                    default=self.transform,
-                    option=OPT_SERIALIZE_NUMPY | OPT_OMIT_MICROSECONDS,
+                return cast(
+                    bytes,
+                    json_encoder(
+                        content,
+                        json_encode_fn=partial(
+                            dumps, option=OPT_SERIALIZE_NUMPY | OPT_OMIT_MICROSECONDS
+                        ),
+                        post_transform_fn=None,
+                        with_encoders=encoders,
+                    ),
                 )
             return super().make_response(content)
         except (AttributeError, ValueError, TypeError) as e:  # pragma: no cover

--- a/esmerald/routing/_internal.py
+++ b/esmerald/routing/_internal.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, create_model
 from pydantic.fields import FieldInfo
 
 from esmerald.datastructures import UploadFile
-from esmerald.encoders import ENCODER_TYPES, is_body_encoder
+from esmerald.encoders import LILYA_ENCODER_TYPES, is_body_encoder
 from esmerald.enums import EncodingType
 from esmerald.openapi.params import ResponseParam
 from esmerald.params import Body
@@ -62,7 +62,7 @@ def convert_annotation_to_pydantic_model(field_annotation: Any) -> Any:
 
     if (
         not isinstance(field_annotation, BaseModel)
-        and any(encoder.is_type(field_annotation) for encoder in ENCODER_TYPES)
+        and any(encoder.is_type(field_annotation) for encoder in LILYA_ENCODER_TYPES.get())
         and inspect.isclass(field_annotation)
     ):
         field_definitions: Dict[str, Any] = {}

--- a/esmerald/transformers/signature.py
+++ b/esmerald/transformers/signature.py
@@ -19,7 +19,7 @@ from typing import (
 from orjson import loads
 from pydantic import ValidationError, create_model
 
-from esmerald.encoders import ENCODER_TYPES, Encoder
+from esmerald.encoders import LILYA_ENCODER_TYPES, Encoder
 from esmerald.exceptions import (
     HTTPException,
     ImproperlyConfigured,
@@ -516,7 +516,7 @@ class SignatureFactory(ArbitraryExtraBaseModel):
             Any: The encoder found, or None if no encoder matches.
         """
         origin = get_origin(annotation)
-        for encoder in ENCODER_TYPES:
+        for encoder in LILYA_ENCODER_TYPES.get():
             if not origin and encoder.is_type(annotation):
                 return encoder
             elif origin:

--- a/tests/dependencies/test_simple_case_injected_annotation.py
+++ b/tests/dependencies/test_simple_case_injected_annotation.py
@@ -25,7 +25,6 @@ class DocumentAPIView(APIView):
 
 
 def test_injection():
-
     with create_client(routes=[Gateway(handler=DocumentAPIView)]) as client:
         response = client.post("/", json={"name": "test", "content": "test"})
         assert response.status_code == 201

--- a/tests/encoding/test_attrs_encoders.py
+++ b/tests/encoding/test_attrs_encoders.py
@@ -1,14 +1,15 @@
+from collections import deque
 from typing import Any
 
+import pytest
 from attrs import asdict, define, field, has
 
 from esmerald import Gateway, post
-from esmerald.encoders import Encoder, register_esmerald_encoder
+from esmerald.encoders import LILYA_ENCODER_TYPES, Encoder, register_esmerald_encoder
 from esmerald.testclient import create_client
 
 
 class AttrsEncoder(Encoder):
-
     def is_type(self, value: Any) -> bool:
         return has(value)
 
@@ -19,7 +20,14 @@ class AttrsEncoder(Encoder):
         return annotation(**value)
 
 
-register_esmerald_encoder(AttrsEncoder)
+@pytest.fixture(autouse=True, scope="function")
+def additional_encoders():
+    token = LILYA_ENCODER_TYPES.set(deque(LILYA_ENCODER_TYPES.get()))
+    try:
+        register_esmerald_encoder(AttrsEncoder)
+        yield
+    finally:
+        LILYA_ENCODER_TYPES.reset(token)
 
 
 @define
@@ -30,9 +38,9 @@ class AttrItem:
 
 
 def test_can_parse_attrs(test_app_client_factory):
-
     @post("/create")
     async def create(data: AttrItem) -> AttrItem:
+        assert type(LILYA_ENCODER_TYPES.get()[0]) is AttrsEncoder
         return data
 
     with create_client(routes=[Gateway(handler=create)]) as client:
@@ -44,7 +52,6 @@ def test_can_parse_attrs(test_app_client_factory):
 
 
 def test_can_parse_attrs_errors(test_app_client_factory):
-
     @define
     class Item:
         sku: str = field()

--- a/tests/encoding/test_attrs_encoders.py
+++ b/tests/encoding/test_attrs_encoders.py
@@ -5,7 +5,12 @@ import pytest
 from attrs import asdict, define, field, has
 
 from esmerald import Gateway, post
-from esmerald.encoders import LILYA_ENCODER_TYPES, Encoder, register_esmerald_encoder
+from esmerald.encoders import (
+    ENCODER_TYPES,
+    LILYA_ENCODER_TYPES,
+    Encoder,
+    register_esmerald_encoder,
+)
 from esmerald.testclient import create_client
 
 
@@ -35,6 +40,10 @@ class AttrItem:
     name: str = field()
     age: int = field()
     email: str
+
+
+def test_working_overwrite():
+    assert LILYA_ENCODER_TYPES.get() is not ENCODER_TYPES
 
 
 def test_can_parse_attrs(test_app_client_factory):

--- a/tests/encoding/test_register_encoder.py
+++ b/tests/encoding/test_register_encoder.py
@@ -5,7 +5,7 @@ import pytest
 from attrs import asdict, define, field, has
 
 from esmerald import Esmerald, Gateway, post
-from esmerald.encoders import LILYA_ENCODER_TYPES, Encoder
+from esmerald.encoders import ENCODER_TYPES, LILYA_ENCODER_TYPES, Encoder
 from esmerald.testclient import EsmeraldTestClient, create_client
 
 
@@ -34,6 +34,10 @@ def additional_encoders():
         yield
     finally:
         LILYA_ENCODER_TYPES.reset(token)
+
+
+def test_working_overwrite():
+    assert LILYA_ENCODER_TYPES.get() is not ENCODER_TYPES
 
 
 def test_can_parse_attrs(test_app_client_factory):

--- a/tests/encoding/test_register_encoder.py
+++ b/tests/encoding/test_register_encoder.py
@@ -1,14 +1,15 @@
+from collections import deque
 from typing import Any
 
+import pytest
 from attrs import asdict, define, field, has
 
 from esmerald import Esmerald, Gateway, post
-from esmerald.encoders import Encoder
+from esmerald.encoders import LILYA_ENCODER_TYPES, Encoder
 from esmerald.testclient import EsmeraldTestClient, create_client
 
 
 class AttrsEncoder(Encoder):
-
     def is_type(self, value: Any) -> bool:
         return has(value)
 
@@ -26,9 +27,19 @@ class AttrItem:
     email: str
 
 
+@pytest.fixture(autouse=True, scope="function")
+def additional_encoders():
+    token = LILYA_ENCODER_TYPES.set(deque(LILYA_ENCODER_TYPES.get()))
+    try:
+        yield
+    finally:
+        LILYA_ENCODER_TYPES.reset(token)
+
+
 def test_can_parse_attrs(test_app_client_factory):
     @post("/create")
     async def create(data: AttrItem) -> AttrItem:
+        assert type(LILYA_ENCODER_TYPES.get()[0]) is AttrsEncoder
         return data
 
     app = Esmerald(routes=[Gateway(handler=create)], encoders=[AttrsEncoder])
@@ -40,7 +51,6 @@ def test_can_parse_attrs(test_app_client_factory):
 
 
 def test_can_parse_attrs_errors(test_app_client_factory):
-
     @define
     class Item:
         sku: str = field()


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description
Changes:
- Use assigned encoders at requests for json_encoder.
- save encoders as instances to application,
- allow temporary use of a different encoder set
- Use more orjson for more speed
