### PR TITLE
fix, lilya shouldn't use Esmerald encoders for apply_structure

### DIFF
--- a/esmerald/encoders.py
+++ b/esmerald/encoders.py
@@ -32,6 +32,10 @@ class Encoder(EncoderProtocol, Generic[T]):
         """
         raise NotImplementedError("All Esmerald encoders must implement is_type() method.")
 
+    def is_type_structure(self, value: Any) -> bool:
+        """Prevent lilya picking it up for apply_structure."""
+        return False
+
     def serialize(self, obj: Any) -> Any:
         """
         Function that transforms a data structure into a serializable


### PR DESCRIPTION
### Checklist

- [ ] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [ ] I branched out from the latest main or is a sub-branch.

### Summary or description

Changes:
- fix botched fix, so lilya really doesn't consider Esmerald encoders for apply_structure
