### PR TITLE
Pluggable/Extensions: allow string imports instead of classes

### DIFF
--- a/docs/en/docs/extensions.md
+++ b/docs/en/docs/extensions.md
@@ -38,7 +38,7 @@ starting the system.
 
 It is this simple but is it the only way to add a pluggable into the system? **Short answser is no**.
 
-More details about this in [hooking a pluggable into the application](#hooking-pluggables).
+More details about this in [hooking a pluggable into the application](#hooking-pluggables-and-extensions).
 
 ## Extension
 
@@ -174,7 +174,7 @@ And simply start the application.
 
     ```shell
     ESMERALD_SETTINGS_MODULE=AppSettings uvicorn src:app --reload
-    
+
     INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
     INFO:     Started reloader process [28720]
     INFO:     Started server process [28722]
@@ -186,7 +186,7 @@ And simply start the application.
 
     ```shell
     $env:ESMERALD_SETTINGS_MODULE="AppSettings"; uvicorn src:app --reload
-    
+
     INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
     INFO:     Started reloader process [28720]
     INFO:     Started server process [28722]

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -5,6 +5,12 @@ hide:
 
 # Release Notes
 
+## 3.6.1
+
+### Added
+
+- Allow passing extensions as string.
+
 ## 3.6.0
 
 ### Added

--- a/docs_src/pluggables/pluggable.py
+++ b/docs_src/pluggables/pluggable.py
@@ -26,4 +26,8 @@ my_config = PluggableConfig(name="my extension")
 
 pluggable = Pluggable(MyExtension, config=my_config)
 
-app = Esmerald(routes=[], extensions={"my-extension": pluggable})
+# it is also possible to just pass strings instead of pluggables but this way you lose the ability to pass arguments
+app = Esmerald(
+    routes=[],
+    extensions={"my-extension": pluggable, "my-other-extension": Pluggable("path.to.extension")},
+)

--- a/esmerald/applications.py
+++ b/esmerald/applications.py
@@ -1348,7 +1348,7 @@ class Application(Lilya):
             ),
         ] = None,
         extensions: Annotated[
-            Optional[Dict[str, Union[Extension, Pluggable, type[Extension]]]],
+            Optional[Dict[str, Union[Extension, Pluggable, type[Extension], str]]],
             Doc(
                 """
                 A `list` of global extensions from objects inheriting from
@@ -1395,7 +1395,7 @@ class Application(Lilya):
             ),
         ] = None,
         pluggables: Annotated[
-            Optional[Dict[str, Union[Extension, Pluggable, type[Extension]]]],
+            Optional[Dict[str, Union[Extension, Pluggable, type[Extension], str]]],
             Doc(
                 """
                 THIS PARAMETER IS DEPRECATED USE extensions INSTEAD

--- a/esmerald/pluggables/base.py
+++ b/esmerald/pluggables/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from inspect import isclass
 from typing import TYPE_CHECKING, Any, Iterator, Optional, cast
@@ -57,12 +59,12 @@ class Pluggable:
     ```
     """
 
-    def __init__(self, cls: type["ExtensionProtocol"] | str, **options: Any):
+    def __init__(self, cls: type[ExtensionProtocol] | str, **options: Any):
         self.cls_or_string = cls
         self.options = options
 
     @property
-    def cls(self) -> type["ExtensionProtocol"]:
+    def cls(self) -> type[ExtensionProtocol]:
         cls_or_string = self.cls_or_string
         if isinstance(cls_or_string, str):
             self.cls_or_string = cls_or_string = import_string(cls_or_string)
@@ -114,7 +116,7 @@ class Extension(ABC, ExtensionProtocol):
     def __init__(
         self,
         app: Annotated[
-            Optional["Esmerald"],
+            Optional[Esmerald],
             Doc(
                 """
                 An `Esmerald` application instance or subclasses of Esmerald.
@@ -138,7 +140,7 @@ BaseExtension = Extension
 
 
 class ExtensionDict(dict[str, Extension]):
-    def __init__(self, data: Any = None, *, app: "Esmerald"):
+    def __init__(self, data: Any = None, *, app: Esmerald):
         super().__init__(data)
         self.app = app
         self.delayed_extend: Optional[dict[str, dict[str, Any]]] = {}

--- a/esmerald/testclient.py
+++ b/esmerald/testclient.py
@@ -110,8 +110,12 @@ def create_client(
     backend: "Literal['asyncio', 'trio']" = "asyncio",
     backend_options: Optional[Dict[str, Any]] = None,
     interceptors: Optional[List["Interceptor"]] = None,
-    pluggables: Optional[Dict[str, Union["Extension", "Pluggable", type["Extension"]]]] = None,
-    extensions: Optional[Dict[str, Union["Extension", "Pluggable", type["Extension"]]]] = None,
+    pluggables: Optional[
+        Dict[str, Union["Extension", "Pluggable", type["Extension"], str]]
+    ] = None,
+    extensions: Optional[
+        Dict[str, Union["Extension", "Pluggable", type["Extension"], str]]
+    ] = None,
     permissions: Optional[List["Permission"]] = None,
     dependencies: Optional["Dependencies"] = None,
     middleware: Optional[List["Middleware"]] = None,

--- a/tests/pluggables/import_target.py
+++ b/tests/pluggables/import_target.py
@@ -1,0 +1,8 @@
+from loguru import logger
+
+from esmerald import Extension
+
+
+class MyExtension2(Extension):
+    def extend(self) -> None:
+        logger.info("Started extension2")

--- a/tests/pluggables/test_extensions.py
+++ b/tests/pluggables/test_extensions.py
@@ -58,10 +58,20 @@ class MyExtension(Extension):
 
 def test_generates_pluggable():
     app = Esmerald(
-        routes=[], extensions={"test": Pluggable(MyExtension, config=Config(name="my pluggable"))}
+        routes=[],
+        extensions={
+            "test": Pluggable(MyExtension, config=Config(name="my pluggable")),
+            "test2": Pluggable("tests.pluggables.import_target.MyExtension2"),
+            "test3": "tests.pluggables.import_target.MyExtension2",
+        },
     )
 
     assert "test" in app.extensions
+    assert isinstance(app.extensions["test"], Extension)
+    assert "test2" in app.extensions
+    assert isinstance(app.extensions["test2"], Extension)
+    assert "test3" in app.extensions
+    assert isinstance(app.extensions["test3"], Extension)
 
 
 def test_generates_many_pluggables():


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

- Pluggable and extensions support now import strings
