### PR TITLE
change default media_type of Response to None to match LilyaResponse

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -11,6 +11,10 @@ hide:
 
 - Allow passing extensions as string.
 
+### Changed
+
+- Change `media_type` parameter of `Response` from `MediaType.JSON` to `None` to match the default of the underlying lilya Response.
+
 ### Fixed
 
 - OpenAPI responses.

--- a/docs/en/docs/responses.md
+++ b/docs/en/docs/responses.md
@@ -39,7 +39,9 @@ This will allow you to use the [ORJSON](#orjson) and [UJSON](#ujson) as well as 
 
 ### Response
 
-Classic and generic `Response` that fits almost every single use case out there.
+Classic and generic `Response` that fits almost every single use case out there. It behaves like lilya `Response` by default.
+It has a special mode for `media_type="application/json"` (used by handlers) in which it behaves like `make_response` (encodes content).
+This special mode is required for encoding data like datetimes, ...
 
 ```python
 {!> ../../../docs_src/responses/response.py !}

--- a/esmerald/responses/base.py
+++ b/esmerald/responses/base.py
@@ -96,7 +96,7 @@ class Response(LilyaResponse, Generic[T]):
                 The media type used in the response.
                 """
             ),
-        ] = MediaType.JSON,
+        ] = None,
         background: Annotated[
             Optional[Union["BackgroundTask", "BackgroundTasks"]],
             Doc(

--- a/tests/routing/test_proxy_load.py
+++ b/tests/routing/test_proxy_load.py
@@ -28,9 +28,9 @@ def test_can_load_from_proxy(test_client_factory):
         response = client.get("/child/home")
 
         assert response.status_code == 200
-        assert response.json() == "Hello, from proxy"
+        assert response.text == '"Hello, from proxy"'
 
         response = client.get("/esmerald")
 
         assert response.status_code == 200
-        assert response.json() == "Hello, esmerald"
+        assert response.text == '"Hello, esmerald"'

--- a/tests/routing/test_proxy_load.py
+++ b/tests/routing/test_proxy_load.py
@@ -33,4 +33,4 @@ def test_can_load_from_proxy(test_client_factory):
         response = client.get("/esmerald")
 
         assert response.status_code == 200
-        assert response.text == '"Hello, esmerald"'
+        assert response.text == "Hello, esmerald"

--- a/tests/routing/test_routing.py
+++ b/tests/routing/test_routing.py
@@ -565,7 +565,7 @@ def test_protocol_switch(test_client_factory):
     with create_client(routes=mixed_protocol_app) as client:
         response = client.get("/")
         assert response.status_code == 200
-        assert response.json() == "URL: http://testserver/"
+        assert response.text == "URL: http://testserver/"
 
         with client.websocket_connect("/") as session:
             assert session.receive_json() == {"URL": "ws://testserver/"}

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -52,7 +52,7 @@ def test_override(test_client_factory):
     with create_client(routes=[Gateway(handler=route_three)]) as client:
         response = client.get("/three")
 
-        assert response.text == '"Ok"'
+        assert response.text == "Ok"
         assert response.status_code == status.HTTP_103_EARLY_HINTS
 
 
@@ -60,7 +60,7 @@ def test_default(test_client_factory):
     with create_client(routes=[Gateway(handler=route_four)]) as client:
         response = client.get("/four")
 
-        assert response.text == '"Ok"'
+        assert response.text == "Ok"
         assert response.status_code == status.HTTP_200_OK
 
 
@@ -68,7 +68,7 @@ def test_default_decorator(test_client_factory):
     with create_client(routes=[Gateway(handler=route_five)]) as client:
         response = client.get("/five")
 
-        assert response.text == '"Ok"'
+        assert response.text == "Ok"
         assert response.status_code == status.HTTP_207_MULTI_STATUS
 
 
@@ -92,20 +92,20 @@ def test_multiple(test_client_factory):
     ) as client:
         response = client.get("/multi")
 
-        assert response.text == '"Ok"'
+        assert response.text == "Ok"
         assert response.status_code == status.HTTP_207_MULTI_STATUS
 
         response = client.get("/multi/test")
 
-        assert response.text == '"Ok"'
+        assert response.text == "Ok"
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
         response = client.get("/multi/esmerald")
 
-        assert response.text == '"Ok"'
+        assert response.text == "Ok"
         assert response.status_code == status.HTTP_300_MULTIPLE_CHOICES
 
         response = client.get("/multi/other")
 
-        assert response.text == '"Ok"'
+        assert response.text == "Ok"
         assert response.status_code == status.HTTP_207_MULTI_STATUS


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Changes:

- change default media_type of Response to None to match LilyaResponse
