### PR TITLE
fix handling cookies is None in get_cookies

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -5,12 +5,6 @@ hide:
 
 # Release Notes
 
-## 3.6.3
-
-### Fixed
-
-- SessionConfig has a unneccessarily heavily restricted secret_key parameter.
-
 ## 3.6.2
 
 ### Added
@@ -27,6 +21,8 @@ hide:
 ### Fixed
 
 - `bytes` won't be encoded as json when returned from a handler. This would unexpectly lead to a base64 encoding.
+- SessionConfig has a unneccessarily heavily restricted secret_key parameter.
+- Gracefully handle situations where cookies are None in `get_cookies`.
 
 ## 3.6.1
 

--- a/esmerald/__init__.py
+++ b/esmerald/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.6.1"
+__version__ = "3.6.2"
 
 
 from lilya import status

--- a/esmerald/responses/base.py
+++ b/esmerald/responses/base.py
@@ -141,7 +141,7 @@ class Response(ORJSONTransformMixin, LilyaResponse, Generic[T]):
                     )
                 ]
 
-                Response(response_cookies=response_cookies)
+                Response(cookies=response_cookies)
                 ```
                 """
             ),
@@ -163,12 +163,13 @@ class Response(ORJSONTransformMixin, LilyaResponse, Generic[T]):
                     encoders=[PydanticEncoder, MsgSpecEncoder]
                 ]
 
-                Response(response_cookies=response_cookies)
+                Response(cookies=response_cookies)
                 ```
                 """
             ),
         ] = None,
     ) -> None:
+        self.cookies = cookies or []
         super().__init__(
             content=content,
             status_code=status_code,
@@ -177,7 +178,6 @@ class Response(ORJSONTransformMixin, LilyaResponse, Generic[T]):
             background=cast("BackgroundTask", background),
             encoders=encoders,
         )
-        self.cookies = cookies or []
 
     def make_response(self, content: Any) -> bytes | memoryview | str:
         if (
@@ -204,9 +204,6 @@ class Response(ORJSONTransformMixin, LilyaResponse, Generic[T]):
         try:
             # switch to a special mode for MediaType.JSON (default handlers)
             if self.media_type == MediaType.JSON:
-                # "" should serialize to json
-                if content == "":
-                    return b'""'
                 # keep it a serialized json object
                 transform_kwargs.setdefault("post_transform_fn", None)
             # otherwise use default logic of lilya striping '"'

--- a/esmerald/responses/template.py
+++ b/esmerald/responses/template.py
@@ -28,7 +28,7 @@ class TemplateResponse(Response):
         if media_type == MediaType.JSON:  # we assume this is the default
             suffixes = PurePath(template_name).suffixes
             for suffix in suffixes:
-                _type = guess_type("name" + suffix)[0]
+                _type = guess_type(f"name{suffix}")[0]
                 if _type:
                     media_type = _type
                     break


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage. (it is basically the same with handling cookies is None)
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description
Changes:
- fix handling cookies is None in get_cookies
- Optimize get_cookies
- fix wrong example
- remove left-over special handling of an empty string, lilya json encoding can do that now