### PR TITLE
Fix validation of parameters requiring a body

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -24,6 +24,7 @@ hide:
 - `bytes` won't be encoded as json when returned from a handler. This would unexpectly lead to a base64 encoding.
 - SessionConfig has a unneccessarily heavily restricted secret_key parameter.
 - Gracefully handle situations where cookies are None in `get_cookies`.
+- Fix validation of parameters requiring a body.
 
 ## 3.6.1
 

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -20,6 +20,7 @@ hide:
 
 ### Fixed
 
+- `data` and `payload` special kwargs are now allowed when a not-bodyless method is available for the handler. They default to None.
 - `bytes` won't be encoded as json when returned from a handler. This would unexpectly lead to a base64 encoding.
 - SessionConfig has a unneccessarily heavily restricted secret_key parameter.
 - Gracefully handle situations where cookies are None in `get_cookies`.

--- a/esmerald/routing/router.py
+++ b/esmerald/routing/router.py
@@ -1917,6 +1917,9 @@ class Router(BaseRouter):
         return wrapper
 
 
+_body_less_methods = frozenset({"GET", "HEAD"})
+
+
 class HTTPHandler(Dispatcher, OpenAPIFieldInfoMixin, LilyaPath):
     __slots__ = (
         "path",
@@ -2222,12 +2225,18 @@ class HTTPHandler(Dispatcher, OpenAPIFieldInfoMixin, LilyaPath):
         """
         Validates if special words are in the signature.
         """
-        if DATA in self.handler_signature.parameters and "GET" in self.methods:
-            raise ImproperlyConfigured("'data' argument is unsupported for 'GET' request handlers")
-
-        if PAYLOAD in self.handler_signature.parameters and "GET" in self.methods:
+        if DATA in self.handler_signature.parameters and _body_less_methods.issuperset(
+            self.methods
+        ):
             raise ImproperlyConfigured(
-                "'payload' argument is unsupported for 'GET' request handlers"
+                "'data' argument is unsupported for 'GET' and 'HEAD' request handlers"
+            )
+
+        if PAYLOAD in self.handler_signature.parameters and _body_less_methods.issuperset(
+            self.methods
+        ):
+            raise ImproperlyConfigured(
+                "'payload' argument is unsupported for 'GET' and 'HEAD' request handlers"
             )
 
         if SOCKET in self.handler_signature.parameters:

--- a/esmerald/routing/router.py
+++ b/esmerald/routing/router.py
@@ -2243,8 +2243,8 @@ class HTTPHandler(Dispatcher, OpenAPIFieldInfoMixin, LilyaPath):
             if isinstance(parameter.default, Form):
                 if body_less_only:
                     raise ImproperlyConfigured(
-                            f"'{special}' uses Form() which is unsupported when only body-less methods "
-                            "like 'GET' and 'HEAD' are handled"
+                        f"'{special}' uses Form() which is unsupported when only body-less methods "
+                        "like 'GET' and 'HEAD' are handled"
                     )
                 elif not is_optional_union(parameter.annotation):
                     raise ImproperlyConfigured(
@@ -2262,6 +2262,7 @@ class HTTPHandler(Dispatcher, OpenAPIFieldInfoMixin, LilyaPath):
     def validate_handler(self) -> None:
         self.check_handler_function()
         self.validate_annotations()
+        self.validate_bodyless_kwargs()
         self.validate_reserved_kwargs()
 
     async def to_response(self, app: "Esmerald", data: Any) -> LilyaResponse:

--- a/tests/forms/test_forms_data.py
+++ b/tests/forms/test_forms_data.py
@@ -27,27 +27,11 @@ class UserModel(BaseModel):
     name: str
 
 
-@post("/form")
-async def test_form(data: Any = Form()) -> Dict[str, str]:
-    return {"name": data["name"]}
-
-
-@post("/complex-form-pydantic")
-async def test_complex_form_pydantic_dataclass(data: User = Form()) -> User:
-    return data
-
-
-@post("/complex-form-dataclass")
-async def test_complex_form_dataclass(data: UserOut = Form()) -> UserOut:
-    return data
-
-
-@post("/complex-form-basemodel")
-async def test_complex_form_basemodel(data: UserModel = Form()) -> UserModel:
-    return data
-
-
 def test_send_form(test_client_factory):
+    @post("/form")
+    async def test_form(data: Any = Form()) -> Dict[str, str]:
+        return {"name": data["name"]}
+
     data = {"name": "Test"}
 
     with create_client(routes=[Gateway(handler=test_form)]) as client:
@@ -58,6 +42,10 @@ def test_send_form(test_client_factory):
 
 
 def test_send_complex_form_pydantic_dataclass(test_client_factory):
+    @post("/complex-form-pydantic")
+    async def test_complex_form_pydantic_dataclass(data: User = Form()) -> User:
+        return data
+
     data = {"id": 1, "name": "Test"}
     with create_client(
         routes=[Gateway(handler=test_complex_form_pydantic_dataclass)],
@@ -69,6 +57,10 @@ def test_send_complex_form_pydantic_dataclass(test_client_factory):
 
 
 def test_send_complex_form_normal_dataclass(test_client_factory):
+    @post("/complex-form-dataclass")
+    async def test_complex_form_dataclass(data: UserOut = Form()) -> UserOut:
+        return data
+
     data = {"id": 1, "name": "Test"}
     with create_client(
         routes=[Gateway(handler=test_complex_form_dataclass)],
@@ -80,6 +72,10 @@ def test_send_complex_form_normal_dataclass(test_client_factory):
 
 
 def test_send_complex_form_base_model(test_client_factory):
+    @post("/complex-form-basemodel")
+    async def test_complex_form_basemodel(data: UserModel = Form()) -> UserModel:
+        return data
+
     data = {"id": 1, "name": "Test"}
     with create_client(
         routes=[Gateway(handler=test_complex_form_basemodel)],

--- a/tests/forms/test_forms_data.py
+++ b/tests/forms/test_forms_data.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
+import pytest
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 
-from esmerald import Form, Gateway, post
+from esmerald import Form, Gateway, post, route
+from esmerald.exceptions import ImproperlyConfigured
 from esmerald.testclient import create_client
 
 
@@ -86,3 +88,11 @@ def test_send_complex_form_base_model(test_client_factory):
         response = client.post("/complex-form-basemodel", data=data)
         assert response.status_code == 201, response.text
         assert response.json() == {"id": 1, "name": "Test"}
+
+
+def test_get_and_head_data():
+    with pytest.raises(ImproperlyConfigured):
+
+        @route(methods=["GET", "HEAD"])
+        async def start(data: Optional[UserModel]) -> bytes:
+            return b"hello world"

--- a/tests/forms/test_forms_payload.py
+++ b/tests/forms/test_forms_payload.py
@@ -27,27 +27,11 @@ class UserModel(BaseModel):
     name: str
 
 
-@post("/form")
-async def test_form(payload: Any = Form()) -> Dict[str, str]:
-    return {"name": payload["name"]}
-
-
-@post("/complex-form-pydantic")
-async def test_complex_form_pydantic_dataclass(payload: User = Form()) -> User:
-    return payload
-
-
-@post("/complex-form-dataclass")
-async def test_complex_form_dataclass(payload: UserOut = Form()) -> UserOut:
-    return payload
-
-
-@post("/complex-form-basemodel")
-async def test_complex_form_basemodel(payload: UserModel = Form()) -> UserModel:
-    return payload
-
-
 def test_send_form(test_client_factory):
+    @post("/form")
+    async def test_form(payload: Any = Form()) -> Dict[str, str]:
+        return {"name": payload["name"]}
+
     payload = {"name": "Test"}
 
     with create_client(routes=[Gateway(handler=test_form)]) as client:
@@ -58,6 +42,10 @@ def test_send_form(test_client_factory):
 
 
 def test_send_complex_form_pydantic_dataclass(test_client_factory):
+    @post("/complex-form-pydantic")
+    async def test_complex_form_pydantic_dataclass(payload: User = Form()) -> User:
+        return payload
+
     payload = {"id": 1, "name": "Test"}
     with create_client(
         routes=[Gateway(handler=test_complex_form_pydantic_dataclass)],
@@ -69,6 +57,10 @@ def test_send_complex_form_pydantic_dataclass(test_client_factory):
 
 
 def test_send_complex_form_normal_dataclass(test_client_factory):
+    @post("/complex-form-dataclass")
+    async def test_complex_form_dataclass(payload: UserOut = Form()) -> UserOut:
+        return payload
+
     payload = {"id": 1, "name": "Test"}
     with create_client(
         routes=[Gateway(handler=test_complex_form_dataclass)],
@@ -80,6 +72,10 @@ def test_send_complex_form_normal_dataclass(test_client_factory):
 
 
 def test_send_complex_form_base_model(test_client_factory):
+    @post("/complex-form-basemodel")
+    async def test_complex_form_basemodel(payload: UserModel = Form()) -> UserModel:
+        return payload
+
     payload = {"id": 1, "name": "Test"}
     with create_client(
         routes=[Gateway(handler=test_complex_form_basemodel)],

--- a/tests/forms/test_forms_payload.py
+++ b/tests/forms/test_forms_payload.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
+import pytest
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 
-from esmerald import Form, Gateway, post
+from esmerald import Form, Gateway, post, route
+from esmerald.exceptions import ImproperlyConfigured
 from esmerald.testclient import create_client
 
 
@@ -86,3 +88,11 @@ def test_send_complex_form_base_model(test_client_factory):
         response = client.post("/complex-form-basemodel", data=payload)
         assert response.status_code == 201, response.text
         assert response.json() == {"id": 1, "name": "Test"}
+
+
+def test_get_and_head_payload():
+    with pytest.raises(ImproperlyConfigured):
+
+        @route(methods=["GET", "HEAD"])
+        async def start(payload: Optional[UserModel]) -> bytes:
+            return b"hello world"

--- a/tests/forms/test_forms_route.py
+++ b/tests/forms/test_forms_route.py
@@ -1,6 +1,10 @@
+from typing import Optional, Union
+
+import pytest
 from pydantic import BaseModel
 
 from esmerald import Esmerald, Form, Request
+from esmerald.exceptions import ImproperlyConfigured
 from esmerald.routing.gateways import Gateway
 from esmerald.routing.handlers import route
 from esmerald.testclient import EsmeraldTestClient
@@ -12,7 +16,7 @@ class Model(BaseModel):
 
 def test_get_and_post():
     @route(methods=["GET", "POST"])
-    async def start(request: Request, form: Model | None = Form()) -> bytes:
+    async def start(request: Request, form: Union[Model, None] = Form()) -> bytes:
         return b"hello world"
 
     app = Esmerald(
@@ -22,3 +26,25 @@ def test_get_and_post():
     client = EsmeraldTestClient(app)
     response = client.get("/")
     assert response.status_code == 200
+
+
+def test_get_and_post_optional():
+    @route(methods=["GET", "POST"])
+    async def start(request: Request, form: Optional[Model] = Form()) -> bytes:
+        return b"hello world"
+
+    app = Esmerald(
+        debug=True,
+        routes=[Gateway("/", handler=start)],
+    )
+    client = EsmeraldTestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+
+
+def test_get_and_head_form():
+    with pytest.raises(ImproperlyConfigured):
+
+        @route(methods=["GET", "HEAD"])
+        async def start(form: Optional[Model] = Form()) -> bytes:
+            return b"hello world"

--- a/tests/forms/test_forms_route.py
+++ b/tests/forms/test_forms_route.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+
+from esmerald import Esmerald, Form, Request
+from esmerald.routing.gateways import Gateway
+from esmerald.routing.handlers import route
+from esmerald.testclient import EsmeraldTestClient
+
+
+class Model(BaseModel):
+    id: str
+
+
+def test_get_and_post():
+    @route(methods=["GET", "POST"])
+    async def start(request: Request, form: Model | None = Form()) -> bytes:
+        return b"hello world"
+
+    app = Esmerald(
+        debug=True,
+        routes=[Gateway("/", handler=start)],
+    )
+    client = EsmeraldTestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

- Fix `data` and `payload` special keyword arguments so they are allowed when another method than one without a body (HEAD, GET) is available,
- Fix validation of parameters requiring a body including Form
- Fix some warnings