### PR TITLE
Fix template response

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -19,7 +19,7 @@ accessible via `from esmerald import Controller`.
 
 ## Fixed
 
-- Fix returning strings (or using templates) causes " escaped.
+- Fix escaped " in TemplateResponse.
 - Fix TemplateResponse's auto-detection of the media-type when used directly.
 
 ## 3.6.2

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -17,6 +17,11 @@ hide:
 - Expose `Controller` in `esmerald` as alternative to `APIView`. This was already available to use but not directly
 accessible via `from esmerald import Controller`.
 
+## Fixed
+
+- Fix returning strings (or using templates) causes " escaped.
+- Fix TemplateResponse's auto-detection of the media-type when used directly.
+
 ## 3.6.2
 
 ### Added

--- a/esmerald/__init__.py
+++ b/esmerald/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.6.2"
+__version__ = "3.6.3"
 
 
 from lilya import status

--- a/esmerald/responses/template.py
+++ b/esmerald/responses/template.py
@@ -23,7 +23,7 @@ class TemplateResponse(Response):
         background: Optional[Union["BackgroundTask", "BackgroundTasks"]] = None,
         headers: Optional[Dict[str, Any]] = None,
         cookies: Optional["ResponseCookies"] = None,
-        media_type: Union[MediaType, str] = MediaType.HTML,
+        media_type: Union[MediaType, str] = MediaType.JSON,
     ):
         if media_type == MediaType.JSON:  # we assume this is the default
             suffixes = PurePath(template_name).suffixes
@@ -38,6 +38,8 @@ class TemplateResponse(Response):
         self.template = template_engine.get_template(template_name)
         self.context = context or {}
         content = self.template.render(**context)
+        if isinstance(content, str):
+            content = content.encode(self.charset)
         super().__init__(
             content=content,
             status_code=status_code,

--- a/esmerald/responses/template.py
+++ b/esmerald/responses/template.py
@@ -38,6 +38,7 @@ class TemplateResponse(Response):
         self.template = template_engine.get_template(template_name)
         self.context = context or {}
         content = self.template.render(**context)
+        # ensure template string is not mangled
         if isinstance(content, str):
             content = content.encode(self.charset)
         super().__init__(

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -43,10 +43,15 @@ def test_engine_jinja_and_mako(engine, template_dir: "pathlib.Path") -> None:
     assert isinstance(app.template_engine, engine)
 
 
-def test_templates_starlette(template_dir, test_client_factory):
+@pytest.mark.parametrize("apostrophe", ["'", '"'])
+def test_templates_starlette(template_dir, test_client_factory, apostrophe):
     path = os.path.join(template_dir, "index.html")
     with open(path, "w") as file:
-        file.write("<html>Hello, <a href='{{ url_for('homepage') }}'>world</a></html>")
+        file.write(
+            "<html>Hello, <a href='{{ url_for('homepage') }}'>world</a></html>".replace(
+                "'", apostrophe
+            )
+        )
 
     @get()
     async def homepage(request: Request) -> Template:
@@ -62,7 +67,9 @@ def test_templates_starlette(template_dir, test_client_factory):
     )
     client = EsmeraldTestClient(app)
     response = client.get("/")
-    assert response.text == "<html>Hello, <a href='http://testserver/'>world</a></html>"
+    assert response.text == "<html>Hello, <a href='http://testserver/'>world</a></html>".replace(
+        "'", apostrophe
+    )
 
 
 def test_alternative_template(template_dir, test_client_factory):


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Changes:

- Fix using templates causes " escaped.
- Fix TemplateResponse's auto-detection of the media-type when used directly.
- bump version
