### PR TITLE
strings should be only mangled when the response type is JSON

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -21,6 +21,7 @@ accessible via `from esmerald import Controller`.
 
 - Fix escaped " in TemplateResponse.
 - Fix TemplateResponse's auto-detection of the media-type when used directly.
+- Don't mangle strings by default for other media-types than json.
 
 ## 3.6.2
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -57,7 +57,7 @@ def route_nine() -> None:
 
 @get("/ten", media_type=MediaType.TEXT)
 def route_ten() -> str:
-    return "hello"
+    return "hel\"'lo"
 
 
 def test_ujson_response(test_client_factory):
@@ -123,7 +123,7 @@ def test_str_returnal_non_json(test_client_factory):
     with create_client(routes=[Gateway(handler=route_ten)]) as client:
         response = client.get("/ten")
 
-        assert response.text == "hello"
+        assert response.text == "hel\"'lo"
 
 
 def test_implicit_none_returnal(test_client_factory):

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -3,6 +3,7 @@ from typing import Union
 from lilya import status
 
 from esmerald import Response
+from esmerald.enums import MediaType
 from esmerald.responses.encoders import ORJSONResponse, UJSONResponse
 from esmerald.routing.gateways import Gateway
 from esmerald.routing.handlers import get
@@ -52,6 +53,11 @@ def route_eight() -> str:
 @get("/nine")
 def route_nine() -> None:
     pass
+
+
+@get("/ten", media_type=MediaType.TEXT)
+def route_ten() -> str:
+    return "hello"
 
 
 def test_ujson_response(test_client_factory):
@@ -111,6 +117,13 @@ def test_str_returnal(test_client_factory):
         response = client.get("/eight")
 
         assert response.text == '"hello"'
+
+
+def test_str_returnal_non_json(test_client_factory):
+    with create_client(routes=[Gateway(handler=route_ten)]) as client:
+        response = client.get("/ten")
+
+        assert response.text == "hello"
 
 
 def test_implicit_none_returnal(test_client_factory):


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

strings should be only mangled when the response type is JSON
Why?

Otherwise when media_type is e.g. text/html, all apostrophes are escaped. I think this is unexpected.
@tarsil what do you think?