### PR TITLE
Fix crashes in tests due to a reused registry

### DIFF
--- a/docs/en/docs/databases/edgy/models.md
+++ b/docs/en/docs/databases/edgy/models.md
@@ -39,7 +39,7 @@ with Edgy.
 
 === "settings.py"
 
-    ```python hl_lines="10-12"
+    ```python hl_lines="12-14"
     {!> ../../../docs_src/databases/edgy/settings/settings.py !}
     ```
 

--- a/docs/en/docs/databases/edgy/models.md
+++ b/docs/en/docs/databases/edgy/models.md
@@ -49,6 +49,12 @@ with Edgy.
     {!> ../../../docs_src/databases/edgy/settings/models.py !}
     ```
 
+=== "app.py"
+
+    ```python
+    {!> ../../../docs_src/databases/edgy/settings/app.py !}
+    ```
+
 You simply isolated your common database connection and registry inside the globally accessible
 settings and with that you can import in any Esmerald application, ChildEsmerald or whatever you
 prefer without the need of repeating yourself.

--- a/docs/en/docs/databases/edgy/models.md
+++ b/docs/en/docs/databases/edgy/models.md
@@ -42,7 +42,6 @@ with Edgy.
     ```python hl_lines="12-14"
     {!> ../../../docs_src/databases/edgy/settings/settings.py !}
     ```
-
 === "models.py"
 
     ```python hl_lines="17 32"

--- a/docs_src/databases/edgy/check_password.py
+++ b/docs_src/databases/edgy/check_password.py
@@ -1,21 +1,6 @@
 from pydantic import EmailStr
 
-from esmerald.conf import settings
-from esmerald.contrib.auth.edgy.base_user import User as BaseUser
-
-database, models = settings.registry
-
-
-class User(BaseUser):
-    """
-    Inherits from the BaseUser all the fields and adds extra unique ones.
-    """
-
-    class Meta:
-        registry = models
-
-    def __str__(self):
-        return f"{self.email} - {self.last_login}"
+from eddy import monkay
 
 
 # Check if password is valid or correct
@@ -23,7 +8,10 @@ async def check_password(email: EmailStr, password: str) -> bool:
     """
     Check if the password of a user is correct.
     """
-    user: User = await User.query.get(email=email)
+    registry = monkay.instance.registry
+    async with registry:
+        User = registry.get_model("User")
+        user: User = await User.query.get(email=email)
 
-    is_valid_password = await user.check_password(password)
-    return is_valid_password
+        is_valid_password = await user.check_password(password)
+        return is_valid_password

--- a/docs_src/databases/edgy/create_superuser.py
+++ b/docs_src/databases/edgy/create_superuser.py
@@ -1,21 +1,5 @@
 from pydantic import EmailStr
-
-from esmerald.conf import settings
-from esmerald.contrib.auth.edgy.base_user import User as BaseUser
-
-models = settings.registry
-
-
-class User(BaseUser):
-    """
-    Inherits from the BaseUser all the fields and adds extra unique ones.
-    """
-
-    class Meta:
-        registry = models
-
-    def __str__(self):
-        return f"{self.email} - {self.last_login}"
+from edgy import monkay
 
 
 async def create_superuser(
@@ -24,11 +8,14 @@ async def create_superuser(
     """
     Creates a superuser in the database.
     """
-    user = await User.query.create_superuser(
-        username=username,
-        password=password,
-        email=email,
-        first_name=first_name,
-        last_name=last_name,
-    )
-    return user
+    registry = monkay.instance.registry
+    async with registry:
+        User = registry.get_model("User")
+        user = await User.query.create_superuser(
+            username=username,
+            password=password,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+        )
+        return user

--- a/docs_src/databases/edgy/create_superuser.py
+++ b/docs_src/databases/edgy/create_superuser.py
@@ -3,7 +3,7 @@ from pydantic import EmailStr
 from esmerald.conf import settings
 from esmerald.contrib.auth.edgy.base_user import User as BaseUser
 
-database, models = settings.registry
+models = settings.registry
 
 
 class User(BaseUser):

--- a/docs_src/databases/edgy/create_user.py
+++ b/docs_src/databases/edgy/create_user.py
@@ -1,21 +1,6 @@
 from pydantic import EmailStr
 
-from esmerald.conf import settings
-from esmerald.contrib.auth.edgy.base_user import User as BaseUser
-
-models = settings.registry
-
-
-class User(BaseUser):
-    """
-    Inherits from the BaseUser all the fields and adds extra unique ones.
-    """
-
-    class Meta:
-        registry = models
-
-    def __str__(self):
-        return f"{self.email} - {self.last_login}"
+from edgy import monkay
 
 
 async def create_user(
@@ -24,11 +9,14 @@ async def create_user(
     """
     Creates a user in the database.
     """
-    user = await User.query.create_user(
-        username=username,
-        password=password,
-        email=email,
-        first_name=first_name,
-        last_name=last_name,
-    )
-    return user
+    registry = monkay.instance.registry
+    async with registry:
+        User = registry.get_model("User")
+        user = await User.query.create_user(
+            username=username,
+            password=password,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+        )
+        return user

--- a/docs_src/databases/edgy/create_user.py
+++ b/docs_src/databases/edgy/create_user.py
@@ -3,7 +3,7 @@ from pydantic import EmailStr
 from esmerald.conf import settings
 from esmerald.contrib.auth.edgy.base_user import User as BaseUser
 
-database, models = settings.registry
+models = settings.registry
 
 
 class User(BaseUser):

--- a/docs_src/databases/edgy/models.py
+++ b/docs_src/databases/edgy/models.py
@@ -36,13 +36,14 @@ class User(BaseUser):
         return f"{self.email} - {self.role}"
 
 
-# Create the db and tables
-# Don't use this in production! Use Alembic or any tool to manage
-# The migrations for you
-await models.create_all()
+async with models:
+    # Create the db and tables
+    # Don't use this in production! Use Alembic or any tool to manage
+    # The migrations for you
+    await models.create_all()
 
-await User.query.create(is_active=False)
+    await User.query.create(is_active=False)
 
-user = await User.query.get(id=1)
-print(user)
-# User(id=1)
+    user = await User.query.get(id=1)
+    print(user)
+    # User(id=1)

--- a/docs_src/databases/edgy/set_password.py
+++ b/docs_src/databases/edgy/set_password.py
@@ -1,21 +1,5 @@
 from pydantic import EmailStr
-
-from esmerald.conf import settings
-from esmerald.contrib.auth.edgy.base_user import User as BaseUser
-
-database, models = settings.registry
-
-
-class User(BaseUser):
-    """
-    Inherits from the BaseUser all the fields and adds extra unique ones.
-    """
-
-    class Meta:
-        registry = models
-
-    def __str__(self):
-        return f"{self.email} - {self.last_login}"
+from edgy import monkay
 
 
 # Update password
@@ -23,6 +7,9 @@ async def set_password(email: EmailStr, password: str) -> None:
     """
     Set the password of a user is correct.
     """
-    user: User = await User.query.get(email=email)
+    registry = monkay.instance.registry
+    async with registry:
+        User = registry.get_model("User")
+        user: User = await User.query.get(email=email)
 
-    await user.set_password(password)
+        await user.set_password(password)

--- a/docs_src/databases/edgy/settings/app.py
+++ b/docs_src/databases/edgy/settings/app.py
@@ -35,9 +35,7 @@ def get_application():
     monkay.evaluate_settings_once(ignore_import_errors=False)  # import manually
 
     # now the project is in the search path and we can import
-    from my_project.utils import get_db_connection
-
-    registry = get_db_connection()
+    registry = settings.registry
 
     app = registry.asgi(
         Esmerald(

--- a/docs_src/databases/edgy/settings/app.py
+++ b/docs_src/databases/edgy/settings/app.py
@@ -1,0 +1,52 @@
+import sys
+
+from esmerald import Esmerald, Include
+
+
+def build_path():
+    """
+    Builds the path of the project and project root.
+    """  #
+    SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
+
+    if SITE_ROOT not in sys.path:
+        sys.path.append(SITE_ROOT)
+        # in case of an application model with apps
+        sys.path.append(os.path.join(SITE_ROOT, "apps"))
+
+
+def disable_edgy_settings_load():
+    os.environ["EDGY_SETTINGS_MODULE"] = ""
+
+
+def get_application():
+    """
+    Encapsulating in methods can be useful for controlling the import order but is optional.
+    """
+    # first call build_path
+    build_path()
+    # this is optional, for rewiring edgy settings to esmerald settings
+    disable_edgy_settings_load()  # disable any settings load
+    # import edgy now
+    from edgy import Instance, monkay
+    from esmerald.conf import settings
+
+    monkay.settings = lambda: settings.edgy_settings  # rewire
+    monkay.evaluate_settings_once(ignore_import_errors=False)  # import manually
+
+    # now the project is in the search path and we can import
+    from my_project.utils import get_db_connection
+
+    registry = get_db_connection()
+
+    app = registry.asgi(
+        Esmerald(
+            routes=[Include(namespace="my_project.urls")],
+        )
+    )
+
+    monkay.set_instance(Instance(registry=registry, app=app))
+    return app
+
+
+app = get_application()

--- a/docs_src/databases/edgy/settings/settings.py
+++ b/docs_src/databases/edgy/settings/settings.py
@@ -1,11 +1,14 @@
 from typing import Tuple
 
+from functools import cached_property
 from edgy import Registry
 
 from esmerald.conf.global_settings import EsmeraldAPISettings
 
 
 class AppSettings(EsmeraldAPISettings):
-    @property
+    # this strategy works only when there is a single set of models (no clashing model names, no redefinitions)
+    # otherwise have a look in esmerald tests how it is solved
+    @cached_property
     def registry(self) -> Registry:
         return Registry("<YOUR-SQL-QUERY-STRING")

--- a/docs_src/databases/edgy/settings/settings.py
+++ b/docs_src/databases/edgy/settings/settings.py
@@ -1,9 +1,12 @@
-from typing import Tuple
+from typing import TYPE_CHECKING
 
 from functools import cached_property
 from edgy import Registry
 
 from esmerald.conf.global_settings import EsmeraldAPISettings
+
+if TYPE_CHECKING:
+    from edgy import EdgySettings
 
 
 class AppSettings(EsmeraldAPISettings):
@@ -12,3 +15,10 @@ class AppSettings(EsmeraldAPISettings):
     @cached_property
     def registry(self) -> Registry:
         return Registry("<YOUR-SQL-QUERY-STRING")
+
+    # optional, in case we want a centralized place
+    @cached_property
+    def edgy_settings(self) -> "EdgySettings":
+        from edgy import EdgySettings
+
+        return EdgySettings(preloads=["myproject.models"])

--- a/tests/cli/simple/test_custom_directive.py
+++ b/tests/cli/simple/test_custom_directive.py
@@ -50,7 +50,6 @@ async def create_test_database():
     try:
         with models.database.force_rollback(False):
             async with models:
-                User.add_to_registry(models)
                 await models.create_all()
                 yield
                 await models.drop_all()

--- a/tests/cli/simple/test_custom_directive.py
+++ b/tests/cli/simple/test_custom_directive.py
@@ -3,11 +3,9 @@ import shutil
 
 import pytest
 
-from esmerald.conf import settings
-from tests.cli.user import User
+from tests.cli.user import User, models
 from tests.cli.utils import run_cmd
 
-models = settings.edgy_registry
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/cli/test_custom_directive.py
+++ b/tests/cli/test_custom_directive.py
@@ -48,8 +48,6 @@ async def create_test_database():
     try:
         with models.database.force_rollback(False):
             async with models:
-                # we readd the right User
-                User.add_to_registry(models)
                 await models.create_all()
                 yield
                 await models.drop_all()

--- a/tests/cli/test_custom_directive.py
+++ b/tests/cli/test_custom_directive.py
@@ -3,11 +3,9 @@ import shutil
 
 import pytest
 
-from esmerald.conf import settings
-from tests.cli.user import User
+from tests.cli.user import User, models
 from tests.cli.utils import run_cmd
 
-models = settings.edgy_registry
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/cli/user.py
+++ b/tests/cli/user.py
@@ -5,7 +5,7 @@ import pytest
 
 from esmerald.conf import settings
 
-models = settings.edgy_registry
+models = edgy.Registry(settings.edgy_database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/cli/user.py
+++ b/tests/cli/user.py
@@ -9,7 +9,7 @@ models = settings.edgy_registry
 pytestmark = pytest.mark.anyio
 
 
-class User(edgy.Model):
+class User(edgy.StrictModel):
     """
     Base model used for a custom user of any application.
     """

--- a/tests/databases/edgy/test_base_user.py
+++ b/tests/databases/edgy/test_base_user.py
@@ -2,12 +2,13 @@ import random
 import string
 from uuid import uuid4
 
+import edgy
 import pytest
 
 from esmerald.conf import settings
 from esmerald.contrib.auth.edgy.base_user import AbstractUser
 
-models = settings.edgy_registry
+models = edgy.Registry(settings.edgy_registry.database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/databases/edgy/test_base_user.py
+++ b/tests/databases/edgy/test_base_user.py
@@ -8,8 +8,7 @@ import pytest
 from esmerald.conf import settings
 from esmerald.contrib.auth.edgy.base_user import AbstractUser
 
-# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
-models = edgy.Registry(settings.edgy_registry.database)
+models = edgy.Registry(settings.edgy_database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/databases/edgy/test_base_user.py
+++ b/tests/databases/edgy/test_base_user.py
@@ -8,6 +8,7 @@ import pytest
 from esmerald.conf import settings
 from esmerald.contrib.auth.edgy.base_user import AbstractUser
 
+# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
 models = edgy.Registry(settings.edgy_registry.database)
 pytestmark = pytest.mark.anyio
 

--- a/tests/databases/edgy/test_middleware_data.py
+++ b/tests/databases/edgy/test_middleware_data.py
@@ -19,6 +19,7 @@ from esmerald.contrib.auth.edgy.middleware import JWTAuthMiddleware
 from esmerald.security.jwt.token import Token
 from esmerald.testclient import create_client
 
+# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
 models = Registry(settings.edgy_registry.database)
 pytestmark = pytest.mark.anyio
 

--- a/tests/databases/edgy/test_middleware_data.py
+++ b/tests/databases/edgy/test_middleware_data.py
@@ -19,8 +19,7 @@ from esmerald.contrib.auth.edgy.middleware import JWTAuthMiddleware
 from esmerald.security.jwt.token import Token
 from esmerald.testclient import create_client
 
-# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
-models = Registry(settings.edgy_registry.database)
+models = Registry(settings.edgy_database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/databases/edgy/test_middleware_data.py
+++ b/tests/databases/edgy/test_middleware_data.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import pytest
 from anyio import from_thread, sleep, to_thread
-from edgy import ObjectNotFound
+from edgy import ObjectNotFound, Registry
 from httpx import ASGITransport, AsyncClient
 from lilya.middleware import DefineMiddleware as LilyaMiddleware
 from pydantic import BaseModel
@@ -19,7 +19,7 @@ from esmerald.contrib.auth.edgy.middleware import JWTAuthMiddleware
 from esmerald.security.jwt.token import Token
 from esmerald.testclient import create_client
 
-models = settings.edgy_registry
+models = Registry(settings.edgy_registry.database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/databases/edgy/test_middleware_payload.py
+++ b/tests/databases/edgy/test_middleware_payload.py
@@ -19,6 +19,7 @@ from esmerald.contrib.auth.edgy.middleware import JWTAuthMiddleware
 from esmerald.security.jwt.token import Token
 from esmerald.testclient import create_client
 
+# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
 models = Registry(settings.edgy_registry.database)
 pytestmark = pytest.mark.anyio
 

--- a/tests/databases/edgy/test_middleware_payload.py
+++ b/tests/databases/edgy/test_middleware_payload.py
@@ -19,8 +19,7 @@ from esmerald.contrib.auth.edgy.middleware import JWTAuthMiddleware
 from esmerald.security.jwt.token import Token
 from esmerald.testclient import create_client
 
-# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
-models = Registry(settings.edgy_registry.database)
+models = Registry(settings.edgy_database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/databases/edgy/test_middleware_payload.py
+++ b/tests/databases/edgy/test_middleware_payload.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import pytest
 from anyio import from_thread, sleep, to_thread
-from edgy import ObjectNotFound
+from edgy import ObjectNotFound, Registry
 from httpx import ASGITransport, AsyncClient
 from lilya.middleware import DefineMiddleware as LilyaMiddleware
 from pydantic import BaseModel
@@ -19,7 +19,7 @@ from esmerald.contrib.auth.edgy.middleware import JWTAuthMiddleware
 from esmerald.security.jwt.token import Token
 from esmerald.testclient import create_client
 
-models = settings.edgy_registry
+models = Registry(settings.edgy_registry.database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/databases/edgy/test_serialization.py
+++ b/tests/databases/edgy/test_serialization.py
@@ -10,7 +10,7 @@ from httpx import ASGITransport, AsyncClient
 from esmerald import Esmerald, Gateway, post
 from esmerald.conf import settings
 
-models = settings.edgy_registry
+models = edgy.Registry(settings.edgy_database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/dependencies/test_simple_case_injected.py
+++ b/tests/dependencies/test_simple_case_injected.py
@@ -11,7 +11,7 @@ from esmerald.injector import Inject
 from esmerald.routing.apis.views import APIView
 from esmerald.routing.gateways import Gateway
 
-models = settings.edgy_registry
+models = edgy.Registry(settings.edgy_database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/dependencies/test_simple_case_injected_no_construct.py
+++ b/tests/dependencies/test_simple_case_injected_no_construct.py
@@ -11,7 +11,7 @@ from esmerald.injector import Inject
 from esmerald.routing.apis.views import APIView
 from esmerald.routing.gateways import Gateway
 
-models = settings.edgy_registry
+models = edgy.Registry(settings.edgy_registry.database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/dependencies/test_simple_case_injected_no_construct.py
+++ b/tests/dependencies/test_simple_case_injected_no_construct.py
@@ -11,6 +11,7 @@ from esmerald.injector import Inject
 from esmerald.routing.apis.views import APIView
 from esmerald.routing.gateways import Gateway
 
+# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
 models = edgy.Registry(settings.edgy_registry.database)
 pytestmark = pytest.mark.anyio
 

--- a/tests/dependencies/test_simple_case_injected_no_construct.py
+++ b/tests/dependencies/test_simple_case_injected_no_construct.py
@@ -12,7 +12,7 @@ from esmerald.routing.apis.views import APIView
 from esmerald.routing.gateways import Gateway
 
 # create a local Registry with the data of the settings registry. We register models and don't want to pollute it
-models = edgy.Registry(settings.edgy_registry.database)
+models = edgy.Registry(settings.edgy_database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/middleware/complex/test_complex.py
+++ b/tests/middleware/complex/test_complex.py
@@ -11,6 +11,7 @@ from esmerald.routing.handlers import get, post, put
 from esmerald.routing.views import APIView
 from esmerald.testclient import create_client
 
+# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
 models = edgy.Registry(settings.edgy_registry.database)
 jwt_config = JWTConfig(signing_key="cenas", auth_header_types=["Bearer", "Token"])
 

--- a/tests/middleware/complex/test_complex.py
+++ b/tests/middleware/complex/test_complex.py
@@ -1,3 +1,4 @@
+import edgy
 import pytest
 from lilya.types import ASGIApp
 
@@ -10,7 +11,7 @@ from esmerald.routing.handlers import get, post, put
 from esmerald.routing.views import APIView
 from esmerald.testclient import create_client
 
-models = settings.edgy_registry
+models = edgy.Registry(settings.edgy_registry.database)
 jwt_config = JWTConfig(signing_key="cenas", auth_header_types=["Bearer", "Token"])
 
 

--- a/tests/middleware/complex/test_complex.py
+++ b/tests/middleware/complex/test_complex.py
@@ -11,8 +11,7 @@ from esmerald.routing.handlers import get, post, put
 from esmerald.routing.views import APIView
 from esmerald.testclient import create_client
 
-# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
-models = edgy.Registry(settings.edgy_registry.database)
+models = edgy.Registry(settings.edgy_database)
 jwt_config = JWTConfig(signing_key="cenas", auth_header_types=["Bearer", "Token"])
 
 

--- a/tests/middleware/complex/test_with_other.py
+++ b/tests/middleware/complex/test_with_other.py
@@ -14,8 +14,7 @@ from esmerald.requests import Connection
 from esmerald.security.jwt.token import Token
 from esmerald.testclient import create_client
 
-# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
-models = edgy.Registry(settings.edgy_registry.database)
+models = edgy.Registry(settings.edgy_database)
 pytestmark = pytest.mark.anyio
 
 

--- a/tests/middleware/complex/test_with_other.py
+++ b/tests/middleware/complex/test_with_other.py
@@ -14,6 +14,7 @@ from esmerald.requests import Connection
 from esmerald.security.jwt.token import Token
 from esmerald.testclient import create_client
 
+# create a local Registry with the data of the settings registry. We register models and don't want to pollute it
 models = edgy.Registry(settings.edgy_registry.database)
 pytestmark = pytest.mark.anyio
 

--- a/tests/middleware/complex/test_with_other.py
+++ b/tests/middleware/complex/test_with_other.py
@@ -14,7 +14,7 @@ from esmerald.requests import Connection
 from esmerald.security.jwt.token import Token
 from esmerald.testclient import create_client
 
-models = settings.edgy_registry
+models = edgy.Registry(settings.edgy_registry.database)
 pytestmark = pytest.mark.anyio
 
 
@@ -33,8 +33,6 @@ class User(AbstractUser):
 @pytest.fixture(autouse=True, scope="module")
 async def create_test_database():
     try:
-        # add the right user
-        User.add_to_registry(models)
         await models.create_all()
         yield
         await models.drop_all()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -32,6 +32,7 @@ class TestSettings(EsmeraldAPISettings):
 
     @cached_property
     def edgy_registry(self) -> EdgyRegistry:
+        # tests/cli uses this directly. All other should use edgy.Registry(settings.edgy_registry) instead for a clean registry
         database = EdgyDatabaseTestClient(
             "postgresql+asyncpg://postgres:postgres@localhost:5432/esmerald_edgy",
             drop_database=False,

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,7 +4,6 @@ from functools import cached_property
 from typing import Optional, Tuple
 
 import mongoz
-from edgy import Registry as EdgyRegistry
 from edgy.testclient import DatabaseTestClient as EdgyDatabaseTestClient
 from pydantic import ConfigDict
 from saffier import Database, Registry
@@ -30,15 +29,15 @@ class TestSettings(EsmeraldAPISettings):
         database = Database("postgresql+asyncpg://postgres:postgres@localhost:5432/esmerald")
         return database, Registry(database=database)
 
-    @cached_property
-    def edgy_registry(self) -> EdgyRegistry:
-        # tests/cli uses this directly. All other should use edgy.Registry(settings.edgy_registry) instead for a clean registry
-        database = EdgyDatabaseTestClient(
+    @property
+    def edgy_database(self) -> EdgyDatabaseTestClient:
+        # not cached, so always a new object is returned
+        # should be wrapped in a registry
+        return EdgyDatabaseTestClient(
             "postgresql+asyncpg://postgres:postgres@localhost:5432/esmerald_edgy",
             drop_database=False,
             use_existing=True,
         )
-        return EdgyRegistry(database=database)
 
     @cached_property
     def mongoz_registry(self) -> mongoz.Registry:


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

With edgy 0.25.0 a check was introduced so models don't get automatically replaced when a new model with the same name and
the same registry was specified.
Esmerald uses for tests a central settings object with a cached registry on it. Multiple test files define same named models on the same registry. Guess what? Silent replacements, a source of pain and workarounds and now it finally just crashed on the try.

This PR cleans the silent replacements up. It creates a local Registry for all edgy model defining tests except for cli which uses the edgy_registry now exclusively.