### PR TITLE
fix typings & pass through passthrough_body_types and encoders in TemplateResponse and Response

### DIFF
--- a/esmerald/responses/base.py
+++ b/esmerald/responses/base.py
@@ -168,6 +168,20 @@ class Response(ORJSONTransformMixin, LilyaResponse, Generic[T]):
                 """
             ),
         ] = None,
+        passthrough_body_types: Annotated[
+            Union[tuple[type, ...], None],
+            Doc(
+                """
+            A tuple with types, which should be passed through directly to the ASGI server.
+            By default only "bytes" are passed through but some ASGI servers can also handle
+            memoryviews or strings.
+            If set, it should include the "bytes" type.
+            As an alternative you can subclass and set a ClassVar named passthrough_body_types.
+
+            Be warned: this is highly ASGI server specific and may requires you to set the content-length header yourself.
+            """
+            ),
+        ] = None,
     ) -> None:
         self.cookies = cookies or []
         super().__init__(
@@ -177,6 +191,7 @@ class Response(ORJSONTransformMixin, LilyaResponse, Generic[T]):
             media_type=media_type,
             background=cast("BackgroundTask", background),
             encoders=encoders,
+            passthrough_body_types=passthrough_body_types,
         )
 
     def make_response(self, content: Any) -> bytes:

--- a/esmerald/responses/base.py
+++ b/esmerald/responses/base.py
@@ -179,7 +179,7 @@ class Response(ORJSONTransformMixin, LilyaResponse, Generic[T]):
             encoders=encoders,
         )
 
-    def make_response(self, content: Any) -> bytes | memoryview | str:
+    def make_response(self, content: Any) -> bytes:
         if (
             content is None
             or content is NoReturn

--- a/esmerald/responses/template.py
+++ b/esmerald/responses/template.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from mimetypes import guess_type
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
@@ -9,6 +10,7 @@ from esmerald.responses.base import Response
 
 if TYPE_CHECKING:  # pragma: no cover
     from esmerald.background import BackgroundTask, BackgroundTasks
+    from esmerald.encoders import Encoder
     from esmerald.protocols.template import TemplateEngineProtocol
     from esmerald.types import ResponseCookies
 
@@ -24,6 +26,8 @@ class TemplateResponse(Response):
         headers: Optional[Dict[str, Any]] = None,
         cookies: Optional["ResponseCookies"] = None,
         media_type: Union[MediaType, str] = MediaType.JSON,
+        encoders: Union[Sequence["Encoder"], None] = None,
+        passthrough_body_types: Union[tuple[type, ...], None] = None,
     ):
         if media_type == MediaType.JSON:  # we assume this is the default
             suffixes = PurePath(template_name).suffixes
@@ -48,6 +52,8 @@ class TemplateResponse(Response):
             media_type=media_type,
             background=background,
             cookies=cookies,
+            encoders=encoders,
+            passthrough_body_types=passthrough_body_types,
         )
 
     async def __call__(


### PR DESCRIPTION
### Checklist

- [ ] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

- Add missing pass through of parameters
- Fix typings



Needs the PR #476 first to succeed