### PR TITLE
fix circular import from asyncz

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-toml

--- a/esmerald/types.py
+++ b/esmerald/types.py
@@ -23,11 +23,6 @@ from esmerald.routing.gateways import WebSocketGateway
 from esmerald.routing.router import Include
 
 try:
-    from asyncz.schedulers import AsyncIOScheduler
-except ImportError:
-    AsyncIOScheduler = Any  # type: ignore
-
-try:
     from esmerald.core.config.template import TemplateConfig as TemplateConfig
 except MissingDependency:
     TemplateConfig = Any  # type: ignore
@@ -47,6 +42,12 @@ if TYPE_CHECKING:
         WebSocketHandler as WebSocketHandler,  # noqa
     )
     from esmerald.websockets import WebSocket  # noqa
+
+    # prevent ciruclar imports by only exposing when type checking and it is available
+    try:
+        from asyncz.schedulers import AsyncIOScheduler
+    except ImportError:
+        AsyncIOScheduler = Any  # type: ignore
 else:
     HTTPHandler = Any
     Application = Any
@@ -69,6 +70,7 @@ else:
     WebhookGateway = Any
     Esmerald = Any
     EsmeraldAPISettings = Any
+    AsyncIOScheduler = Any
 
 AsyncAnyCallable = Callable[..., Awaitable[Any]]
 HTTPMethod = Literal["GET", "POST", "DELETE", "PATCH", "PUT", "HEAD"]

--- a/esmerald/types.py
+++ b/esmerald/types.py
@@ -43,11 +43,13 @@ if TYPE_CHECKING:
     )
     from esmerald.websockets import WebSocket  # noqa
 
-    # prevent ciruclar imports by only exposing when type checking and it is available
+    # prevent ciruclar and unneccessary imports
+    # by only exposing it when type checking
+    # also only expose if available otherwise fallback to Any
     try:
-        from asyncz.schedulers import AsyncIOScheduler
+        from asyncz.schedulers.types import SchedulerType as SchedulerType  # noqa
     except ImportError:
-        AsyncIOScheduler = Any  # type: ignore
+        SchedulerType = Any  # type: ignore
 else:
     HTTPHandler = Any
     Application = Any
@@ -70,7 +72,7 @@ else:
     WebhookGateway = Any
     Esmerald = Any
     EsmeraldAPISettings = Any
-    AsyncIOScheduler = Any
+    SchedulerType = Any
 
 AsyncAnyCallable = Callable[..., Awaitable[Any]]
 HTTPMethod = Literal["GET", "POST", "DELETE", "PATCH", "PUT", "HEAD"]
@@ -96,7 +98,6 @@ ResponseHeaders = Dict[str, ResponseHeader]
 ResponseCookies = List[Cookie]
 AsyncAnyCallable = Callable[..., Awaitable[Any]]  # type: ignore
 
-SchedulerType = AsyncIOScheduler
 DatetimeType = TypeVar("DatetimeType", bound=datetime)
 
 ParentType = Union[View, Router, Gateway, WebSocketGateway, Esmerald, Include, Application]


### PR DESCRIPTION
### Checklist

- [ ] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description
Changes:
- fix circular import in asyncz tests
- fix deprecation warning due old pre-commit-hooks version
- fix type of SchedulerType