### PR TITLE
fix too early settings imports with programmatically changed env variable

### DIFF
--- a/esmerald/conf/__init__.py
+++ b/esmerald/conf/__init__.py
@@ -12,7 +12,7 @@ ENVIRONMENT_VARIABLE = "ESMERALD_SETTINGS_MODULE"
 
 monkay: Monkay[None, EsmeraldAPISettings] = Monkay(
     globals(),
-    settings_path=os.environ.get(
+    settings_path=lambda: os.environ.get(
         ENVIRONMENT_VARIABLE, "esmerald.conf.global_settings.EsmeraldAPISettings"
     ),
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "msgspec>=0.18.5,<1.0.0",
     "rich>=13.3.1,<15.0.0",
     "typing_extensions>=4.11.0",
-    "monkay>=0.4.0",
+    "monkay>=0.4.1",
 ]
 keywords = [
     "api",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "msgspec>=0.18.5,<1.0.0",
     "rich>=13.3.1,<15.0.0",
     "typing_extensions>=4.11.0",
-    "monkay>=0.3.0",
+    "monkay>=0.4.0",
 ]
 keywords = [
     "api",


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [ ] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

This way we prevent an too early import of settings and don't end up with the wrong ones