### PR TITLE
test: Demonstrate UUID path parameter and PUT method issues in cached endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,10 @@
 # See https://pre-commit.com/hooks.html for more hooks.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
+        stages: [pre-commit]
       - id: check-toml
       - id: debug-statements
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,9 @@
 # See https://pre-commit.com/hooks.html for more hooks.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
-        stages: [pre-commit]
       - id: check-toml
       - id: debug-statements
       - id: check-yaml

--- a/tests/caches/test_cache_with_handler.py
+++ b/tests/caches/test_cache_with_handler.py
@@ -1,12 +1,17 @@
+from uuid import UUID, uuid4
 from pydantic import BaseModel
 
-from esmerald import Controller, Gateway, post
+from esmerald import Controller, Gateway, get, post, put, patch, delete, JSONResponse, JSON
 from esmerald.testclient import create_client
 from esmerald.utils.decorators import cache
 
 
 class Item(BaseModel):
     id: int
+    name: str
+
+class ItemWithUUID(BaseModel):
+    id: UUID
     name: str
 
 
@@ -35,3 +40,72 @@ def test_controller_caching(memory_cache, test_client_factory) -> None:
         response = client.post("/items", json={"id": 1, "name": "Test Item"})
         assert response.status_code == 201
         assert response.json() == {"id": 1, "name": "Test Item"}
+
+
+def test_controller_caching_with_uuid(memory_cache, test_client_factory) -> None:
+    class ItemsUUIDController(Controller):
+        path = "/items"
+
+        @get("/{item_id}")
+        @cache(backend=memory_cache)
+        async def get_item(self, item_id: UUID) -> ItemWithUUID:
+            return {"id": item_id, "name": "Test Item"}
+
+        @post()
+        @cache(backend=memory_cache)
+        async def create_item_with_JSONResponse(self, data: ItemWithUUID) -> JSONResponse:
+            return JSONResponse(content=data)
+
+        @put("/{item_id}")
+        @cache(backend=memory_cache)
+        async def update_item(self, item_id: UUID, data: ItemWithUUID) -> ItemWithUUID:
+            return {"id": item_id, "name": data.name}
+
+        @patch("/{item_id}")
+        @cache(backend=memory_cache)
+        async def update_item(self, item_id: UUID, data: ItemWithUUID) -> ItemWithUUID:
+            return {"id": item_id, "name": data.name}
+
+        @delete("/{item_id}")
+        @cache(backend=memory_cache)
+        async def delete_item(self, item_id: UUID) -> None:
+            return None
+
+        
+
+        @post("/items")
+        @cache(backend=memory_cache)
+        async def create_item(self, data: ItemWithUUID) -> ItemWithUUID:
+            return data
+
+    with create_client(routes=[Gateway(handler=ItemsUUIDController)], debug=True) as client:
+        headers = {"Content-Type": "application/json"}
+        payload = {"id": uuid4().hex, "name": "Test Item"}
+
+        response = client.post("/items", json=payload, headers=headers)
+        assert response.status_code == 201
+        assert UUID(response.json()["id"]).hex == payload["id"]
+        assert response.json()["name"] == payload["name"]
+
+        response = client.post("/items", json=payload, headers=headers)
+        assert response.status_code == 201
+        assert UUID(response.json()["id"]).hex == payload["id"]
+        assert response.json()["name"] == payload["name"]
+
+        response = client.put(f"/items/{payload['id']}", json=payload, headers=headers)
+        assert response.status_code == 200
+        assert UUID(response.json()["id"]).hex == payload["id"]
+        assert response.json()["name"] == payload["name"]
+
+        response = client.patch(f"/items/{payload['id']}", json=payload, headers=headers)
+        assert response.status_code == 200
+        assert UUID(response.json()["id"]).hex == payload["id"]
+        assert response.json()["name"] == payload["name"]
+
+        response = client.delete(f"/items/{payload['id']}", headers=headers)
+        assert response.status_code == 204
+
+        item_id = payload["id"]
+        response = client.get(f"/items/{item_id}", headers=headers)
+        assert response.status_code == 200
+        assert UUID(response.json()["id"]).hex == item_id


### PR DESCRIPTION
### Checklist

- [Yes] The code has 100% test coverage.
- [Yes] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [Yes] I branched out from the latest main or is a sub-branch.

### Summary or description
Issues Identified
1. UUID Path Parameter Issue
When using UUID as path parameters in cached endpoints, there appears to be a problem with how the caching mechanism handles UUID serialization/deserialization or path parameter parsing.

2. Test Client PUT Method Issue
The test client does not properly support PUT method requests for cached endpoints, preventing proper testing of update operations.

Test Cases Added
Added comprehensive test coverage in 
test_controller_caching_with_uuid() that demonstrates both issues Includes full CRUD operations with UUID path parameters:
GET /items/{item_id} - Retrieve by UUID
PUT /items/{item_id} - Issue: PUT method not working with test client
PATCH /items/{item_id} - Partial update by UUID
DELETE /items/{item_id} - Delete by UUID
POST /items - Create with UUID
🔍 Expected vs Actual Behavior
UUID Parameters: Should work seamlessly with cached endpoints
PUT Method: Test client should support PUT requests for cached endpoints