### PR TITLE
generic lifespan support

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -49,6 +49,7 @@ starting a new set of versions from the 0.1.0.
 ### Fixed
 
 - Autodetection of app in cli.
+- Generic lifespan support in `run` directive.
 
 ## 3.9.4
 

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -29,7 +29,7 @@ the async web framework that builds on the strengths of **RavynAPIException** wh
 
 This is not mandatory **at all** but if you want to start using Ravyn right away, you can simply do:
 
-- Replace all `ravyn` imports with `ravyn`.
+- Replace all `esmerald` imports with `ravyn`.
 - No breaking changes in core APIs — projects built on Ravyn should run with minimal adjustments.
 
 Again, **Ravyn** is a fork of RavynAPIException with the same concepts, same everything.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pydantic-settings>=2.9.0",
     "orjson>=3.8.5,<4.0.0",
     "msgspec>=0.18.5,<1.0.0",
+    "monkay>=0.5.0"
 ]
 keywords = [
     "api",


### PR DESCRIPTION
### Checklist

- [ ] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Have generic lifespan support in run directives instead of starlette specific. The monkay dependency is pulled in already.

Other changes:
A lost commit from main including sayer instead of click. I think a rollback of github happened