### PR TITLE
Fix permissions operations AND,OR,NOT.

### DIFF
--- a/ravyn/permissions/utils.py
+++ b/ravyn/permissions/utils.py
@@ -54,10 +54,15 @@ def is_ravyn_permission(permission: Union["BasePermission", Any]) -> bool:
     Returns:
         bool: True if the permission is an instance or subclass of BasePermission, False otherwise.
     """
+    from inspect import isclass
 
     from ravyn.permissions import BasePermission
+    from ravyn.permissions.base import BaseOperationHolder
 
-    return is_class_and_subclass(permission, BasePermission)
+    if isclass(permission):
+        return is_class_and_subclass(permission, BasePermission)
+
+    return isinstance(permission, BaseOperationHolder)
 
 
 def is_lilya_permission(permission: Union[DefinePermission, Any]) -> bool:

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -172,6 +172,12 @@ class DummyPermission(PermissionProtocol):
 class DummyTrue(BasePermission): ...
 
 
+class Op1True(BasePermission): ...
+
+
+class Op2True(BasePermission): ...
+
+
 @pytest.mark.parametrize(
     "permission,result",
     [
@@ -179,6 +185,17 @@ class DummyTrue(BasePermission): ...
         (DummyTrue, True),
         (TestPermission, False),
         (DummyPermission, False),
+        (Op1True, True),
+        (Op2True, True),
+        (~Op1True, True),
+        (Op1True & Op2True, True),
+        (~Op1True & Op2True, True),
+        (Op1True & ~Op2True, True),
+        (~(Op1True & Op2True), True),
+        (Op1True | Op2True, True),
+        (~Op1True | Op2True, True),
+        (Op1True | ~Op2True, True),
+        (~(Op1True | Op2True), True),
     ],
 )
 def test_is_ravyn_permission(permission, result) -> None:

--- a/tests/permissions/test_permissions_operations.py
+++ b/tests/permissions/test_permissions_operations.py
@@ -1,0 +1,265 @@
+from typing import TYPE_CHECKING
+
+from lilya.status import HTTP_200_OK, HTTP_403_FORBIDDEN
+
+from ravyn.permissions import BasePermission
+from ravyn.routing.gateways import Gateway
+from ravyn.routing.handlers import get
+from ravyn.testclient import create_client
+
+if TYPE_CHECKING:
+    from ravyn.requests import Request
+    from ravyn.types import APIGateHandler
+
+
+class BaseTestPermission(BasePermission):
+    custom_header: str = None
+
+    def has_permission(self, request: "Request", controller: "APIGateHandler"):
+        if not request.headers.get(self.custom_header):
+            return False
+        return True
+
+
+class Op1Permission(BaseTestPermission):
+    custom_header = "op1"
+
+
+class Op2Permission(BaseTestPermission):
+    custom_header = "op2"
+
+
+class Op3Permission(BaseTestPermission):
+    custom_header = "op3"
+
+
+def test_permissions_with_single_op() -> None:
+    @get(
+        path="/permissions",
+        permissions=[Op1Permission],
+    )
+    def my_http_route_handler() -> None: ...
+
+    with create_client(
+        routes=[Gateway(handler=my_http_route_handler)],
+    ) as client:
+        response = client.get("/permissions")
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op1": "test"})
+        assert response.status_code == HTTP_200_OK
+
+
+def test_permissions_with_and_ops() -> None:
+    @get(
+        path="/permissions",
+        permissions=[Op1Permission & Op2Permission],
+    )
+    def my_http_route_handler() -> None: ...
+
+    with create_client(
+        routes=[Gateway(handler=my_http_route_handler)],
+    ) as client:
+        response = client.get("/permissions")
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op1": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op2": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op1": "test", "op2": "test"})
+        assert response.status_code == HTTP_200_OK
+
+
+def test_permissions_with_and_plus_extra_ops() -> None:
+    @get(
+        path="/permissions",
+        permissions=[Op1Permission & Op2Permission, Op3Permission],
+    )
+    def my_http_route_handler() -> None: ...
+
+    with create_client(
+        routes=[Gateway(handler=my_http_route_handler)],
+    ) as client:
+        response = client.get("/permissions")
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op3": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op1": "test", "op2": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get(
+            "/permissions", headers={"op1": "test", "op2": "test", "op3": "test"}
+        )
+        assert response.status_code == HTTP_200_OK
+
+
+def test_permissions_with_inverted_and_ops() -> None:
+    @get(
+        path="/permissions",
+        permissions=[~(Op1Permission & Op2Permission)],
+    )
+    def my_http_route_handler() -> None: ...
+
+    with create_client(
+        routes=[Gateway(handler=my_http_route_handler)],
+    ) as client:
+        response = client.get("/permissions")
+        assert response.status_code == HTTP_200_OK
+        response = client.get("/permissions", headers={"op1": "test"})
+        assert response.status_code == HTTP_200_OK
+        response = client.get("/permissions", headers={"op2": "test"})
+        assert response.status_code == HTTP_200_OK
+        response = client.get("/permissions", headers={"op1": "test", "op2": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+
+
+def test_permissions_with_or_ops() -> None:
+    @get(
+        path="/permissions",
+        permissions=[Op1Permission | Op2Permission],
+    )
+    def my_http_route_handler() -> None: ...
+
+    with create_client(
+        routes=[Gateway(handler=my_http_route_handler)],
+    ) as client:
+        response = client.get("/permissions")
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op1": "test"})
+        assert response.status_code == HTTP_200_OK
+        response = client.get("/permissions", headers={"op2": "test"})
+        assert response.status_code == HTTP_200_OK
+        response = client.get("/permissions", headers={"op1": "test", "op2": "test"})
+        assert response.status_code == HTTP_200_OK
+
+
+def test_permissions_with_or_plus_extra_ops() -> None:
+    @get(
+        path="/permissions",
+        permissions=[Op1Permission | Op2Permission, Op3Permission],
+    )
+    def my_http_route_handler() -> None: ...
+
+    with create_client(
+        routes=[Gateway(handler=my_http_route_handler)],
+    ) as client:
+        response = client.get("/permissions")
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op3": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op1": "test", "op3": "test"})
+        assert response.status_code == HTTP_200_OK
+        response = client.get("/permissions", headers={"op2": "test", "op3": "test"})
+        assert response.status_code == HTTP_200_OK
+        response = client.get(
+            "/permissions", headers={"op1": "test", "op2": "test", "op3": "test"}
+        )
+        assert response.status_code == HTTP_200_OK
+
+
+def test_permissions_with_inverted_or_ops() -> None:
+    @get(
+        path="/permissions",
+        permissions=[~(Op1Permission | Op2Permission)],
+    )
+    def my_http_route_handler() -> None: ...
+
+    with create_client(
+        routes=[Gateway(handler=my_http_route_handler)],
+    ) as client:
+        response = client.get("/permissions")
+        assert response.status_code == HTTP_200_OK
+        response = client.get("/permissions", headers={"op1": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op2": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op1": "test", "op2": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+
+
+def test_permissions_with_not_ops() -> None:
+    @get(
+        path="/permissions",
+        permissions=[~Op1Permission],
+    )
+    def my_http_route_handler() -> None: ...
+
+    with create_client(
+        routes=[Gateway(handler=my_http_route_handler)],
+    ) as client:
+        response = client.get("/permissions")
+        assert response.status_code == HTTP_200_OK
+        response = client.get("/permissions", headers={"op1": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+
+
+def test_permissions_with_not_plus_extra_ops() -> None:
+    @get(
+        path="/permissions",
+        permissions=[~Op1Permission, Op2Permission],
+    )
+    def my_http_route_handler() -> None: ...
+
+    with create_client(
+        routes=[Gateway(handler=my_http_route_handler)],
+    ) as client:
+        response = client.get("/permissions")
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op1": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )
+        response = client.get("/permissions", headers={"op2": "test"})
+        assert response.status_code == HTTP_200_OK
+        response = client.get("/permissions", headers={"op1": "test", "op2": "test"})
+        assert response.status_code == HTTP_403_FORBIDDEN
+        assert (
+            response.json().get("detail") == "You do not have permission to perform this action."
+        )


### PR DESCRIPTION
### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description

Fixed a bug in permission operations logic — previously, combining permissions with logical operators (&, |, ~) did not work correctly.
Now, permission combinations like
```python
permissions = [IsAuthenticated & ~ReadOnly]
```
evaluate as expected.

Added missing unit tests to cover all logical operation cases between permissions.
